### PR TITLE
Add new authorisation feature and test user detail

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -6,6 +6,37 @@
   "video": false,
   "baseUrl": "http://localhost:3000",
   "users": {
-    "system": "system@example.com"
+    "system": {
+      "email": "system@example.com",
+      "regimes": ["PAS"]
+    },
+    "installations": {
+      "email": "installations@sroc.gov.uk",
+      "regimes": ["PAS"]
+    },
+    "waste": {
+      "email": "waste@sroc.gov.uk",
+      "regimes": ["WML"]
+    },
+    "water": {
+      "email": "water@sroc.gov.uk",
+      "regimes": ["CFD"]
+    },
+    "admin": {
+      "email": "admin@sroc.gov.uk",
+      "regimes": ["CFD", "PAS", "WML"]
+    },
+    "billing": {
+      "email": "billing@sroc.gov.uk",
+      "regimes": ["CFD", "PAS", "WML"]
+    },
+    "export": {
+      "email": "export@sroc.gov.uk",
+      "regimes": ["CFD", "PAS", "WML"]
+    },
+    "readonly": {
+      "email": "readonly@sroc.gov.uk",
+      "regimes": ["CFD", "PAS", "WML"]
+    }
   }
 }

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/authorisation.feature
+++ b/cypress/integration/authorisation.feature
@@ -1,0 +1,42 @@
+Feature: Authorisation
+
+  As the business responsible for the system
+  I want to ensure
+  That users can only access the features and regimes they are permitted to
+
+  Scenario: Admin role
+    Given I sign in as the 'admin' user
+    When I see the transactions page
+    Then I should see the admin menu
+
+  Scenario: Billing role
+    Given I sign in as the 'billing' user
+    When I see the transactions page
+    Then I should see the billing menu
+    But I should not see the admin menu
+
+  Scenario: Export role
+    Given I sign in as the 'export' user
+    When I see the transactions page
+    Then I should see the transactions menu
+    And I should see download transactions
+    But I should not see the admin menu
+    But I should not see the billing menu
+
+  Scenario: Readonly role
+    Given I sign in as the 'readonly' user
+    When I see the transactions page
+    Then I should see the transactions menu
+    But I should not see download transactions
+    But I should not see the admin menu
+    But I should not see the billing menu
+
+  Scenario Outline: Regimes
+    Given I sign in as the "<regime>" user
+    When I see the transactions page
+    Then I should only see the "<regime>" regime
+    Examples:
+      | regime        |
+      | installations |
+      | waste         |
+      | water         |

--- a/cypress/integration/authorisation/authorisation_steps.js
+++ b/cypress/integration/authorisation/authorisation_steps.js
@@ -1,0 +1,39 @@
+import { And, When, Then, But } from 'cypress-cucumber-preprocessor/steps'
+import TransactionsPage from '../../pages/transactions_page'
+
+When('I see the transactions page', () => {
+  TransactionsPage.mainHeading().contains('Transactions to be billed')
+})
+
+Then('I should see the admin menu', () => {
+  TransactionsPage.adminMenu().should('be.visible')
+})
+
+But('I should not see the admin menu', () => {
+  TransactionsPage.adminMenu().should('not.be.visible')
+})
+
+Then('I should see the billing menu', () => {
+  TransactionsPage.billingMenu().should('be.visible')
+})
+
+But('I should not see the billing menu', () => {
+  TransactionsPage.billingMenu().should('not.be.visible')
+})
+
+Then('I should see the transactions menu', () => {
+  TransactionsPage.transactionMenu().should('be.visible')
+})
+
+And('I should see download transactions', () => {
+  TransactionsPage.downloadTransactionDataMenuItem().should('not.be.null')
+})
+
+But('I should not see download transactions', () => {
+  TransactionsPage.downloadTransactionDataMenuItem().should('not.be.visible')
+})
+
+Then('I should only see the {string} regime', (regime) => {
+  cy.get('.navbar-text').contains(regime, { matchCase: false })
+  TransactionsPage.regimeMenu().should('not.exist')
+})

--- a/cypress/integration/common/sign_in.js
+++ b/cypress/integration/common/sign_in.js
@@ -3,7 +3,7 @@ import SignInPage from '../../pages/sign_in_page'
 
 Given('I sign in as the {string} user', (user) => {
   SignInPage.visit()
-  SignInPage.email().type(Cypress.config().users[user])
+  SignInPage.email().type(Cypress.config().users[user].email)
   SignInPage.password().type(Cypress.env('PASSWORD'))
 
   SignInPage.logIn().click()

--- a/cypress/integration/sign_in/sign_in_steps.js
+++ b/cypress/integration/sign_in/sign_in_steps.js
@@ -6,7 +6,7 @@ Given('I visit the sign in page', () => {
 })
 
 When('I enter my credentials', () => {
-  SignInPage.email().type(Cypress.config().users.system)
+  SignInPage.email().type(Cypress.config().users.system.email)
   SignInPage.password().type(Cypress.env('PASSWORD'))
 
   SignInPage.logIn().click()

--- a/cypress/pages/transactions_page.js
+++ b/cypress/pages/transactions_page.js
@@ -24,6 +24,26 @@ class TransactionsPage {
   static customerColumn () {
     return cy.get('.table > tbody > tr > td:nth-child(4)')
   }
+
+  static transactionMenu () {
+    return cy.get('#navbarTransactionsSelectorLink')
+  }
+
+  static adminMenu () {
+    return cy.get('#navbarAdminSelectorLink')
+  }
+
+  static billingMenu () {
+    return cy.get('#navbarAnnualBillingSelectorLink')
+  }
+
+  static regimeMenu () {
+    return cy.get('#navbarRegimeSelectorLink')
+  }
+
+  static downloadTransactionDataMenuItem () {
+    return cy.get(':nth-child(1) > .nav-item > .dropdown-menu > [href="/regimes/pas/data_export"]')
+  }
 }
 
 export default TransactionsPage


### PR DESCRIPTION
We are intending to update the seeding of the database for non-production environments to include a set of known users. See [Update seed script to create test users](https://github.com/DEFRA/sroc-tcm-admin/pull/305).

As soon as this is merged and available we will have a set of known users with specific roles and access to set regimes. With this knowledge we can create some tests to confirm the authorisation functionality is behaving as expected.

This also serves as a nice example of using the updated user config and includes a Cucumber data table based scenario as a 'Brucie bonus'.