### PR TITLE
Fix transaction feature for all environments

### DIFF
--- a/cypress/integration/transactions.feature
+++ b/cypress/integration/transactions.feature
@@ -1,8 +1,9 @@
 Feature: Transactions
 
   Background:
-    Given I sign in as the 'system' user
+    Given I sign in as the 'admin' user
 
   Scenario: Search for customer
-    When I search for the customer 'A1234B'
-    Then I see only results for customer 'A1234B'
+    When I select the 'Water Quality' regime
+     And I search for the customer 'A60425822C'
+    Then I see only results for customer 'A60425822C'

--- a/cypress/integration/transactions/transaction_steps.js
+++ b/cypress/integration/transactions/transaction_steps.js
@@ -1,4 +1,4 @@
-import { Then, When, Before } from 'cypress-cucumber-preprocessor/steps'
+import { Then, When, And, Before } from 'cypress-cucumber-preprocessor/steps'
 import TransactionsPage from '../../pages/transactions_page'
 
 Before(() => {
@@ -24,7 +24,12 @@ Before(() => {
   }).as('getTransactions')
 })
 
-When('I search for the customer {string}', (customer) => {
+When('I select the {string} regime', (regime) => {
+  TransactionsPage.regimeMenu().click()
+  TransactionsPage.regimeMenuItem(regime).click()
+})
+
+And('I search for the customer {string}', (customer) => {
   TransactionsPage.search().type(customer)
   TransactionsPage.searchBtn().click()
 

--- a/cypress/pages/transactions_page.js
+++ b/cypress/pages/transactions_page.js
@@ -41,6 +41,24 @@ class TransactionsPage {
     return cy.get('#navbarRegimeSelectorLink')
   }
 
+  static regimeMenuItem (regime) {
+    let slug
+
+    switch (regime) {
+      case 'Water Quality':
+        slug = 'cfd'
+        break
+      case 'Installations':
+        slug = 'pas'
+        break
+      case 'Waste':
+        slug = 'wml'
+        break
+    }
+
+    return cy.get(`.nav-item.show > .dropdown-menu > [href="/regimes/${slug}/transactions"]`)
+  }
+
   static downloadTransactionDataMenuItem () {
     return cy.get(':nth-child(1) > .nav-item > .dropdown-menu > [href="/regimes/pas/data_export"]')
   }


### PR DESCRIPTION
We initially thought the problem was that the data across each environment was so different that certain customers only existed in certain places.

Actually, the problem was that in some environments the `system` user is set up differently. This means the regimes it has access to is limited, or it was used previously to access a regime other than `CFD` and this has defaulted when the tests run. So, we've made 2 key changes

- switched to a user we know is set up the same across all 3 environments
- updated the test to ensure the right regime is selected before searching

Knowing this we were able to identify a customer that exists across all 3 environments. With these changes plus some going away and creating all the test users across all non-prod environments, all features are now passing everywhere!