### PR TITLE
Fix Windows issue with S3 upload key

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -64,7 +64,9 @@ module.exports = (on, config) => {
 
   on('task', {
     s3Upload ({ Body, Bucket, remotePath, filename }) {
-      const Key = path.join(remotePath, filename)
+      // We use a template literal to combine the path and filename rather than path.join() to ensure it joins them
+      // with a forward slash as required by S3 (which wouldn't happen if running under Windows).
+      const Key = `${remotePath}/${filename}`
       const client = new S3Client()
       const command = new PutObjectCommand({ Bucket, Key, Body })
 
@@ -75,7 +77,7 @@ module.exports = (on, config) => {
             // If client.send() was successful then resolve the promise so Cypress can continue, returning the remote
             // file path so we can log it.
             data => {
-              resolve(path.join(Bucket, Key))
+              resolve(`${Bucket}/${Key}`)
             },
             // If client.send() failed then reject the promise so Cypress can throw an error
             error => {


### PR DESCRIPTION
We found that the upload functionality didn't work correctly when running under Windows -- the key was incorrectly being set as `import\cfdti.dat.csv` when it should be `import/cfdti.dat.csv` (ie. a backslash rather than a forward slash). This turned out to be because we were using `path.join()` to create the key, which behaves differently under Windows than it does under a UNIX-based OS.

We therefore replace the use of `path.join()` with a template literal to ensure that the key is correctly formatted for uploading to S3.