### PR TITLE
Add legacy CFD feature from Java project

### DIFF
--- a/cypress/integration/legacy/cfd.feature
+++ b/cypress/integration/legacy/cfd.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: CFD (Water Quality) Legacy
 
   Background:

--- a/cypress/integration/legacy/cfd.feature
+++ b/cypress/integration/legacy/cfd.feature
@@ -9,7 +9,11 @@ Feature: CFD (Water Quality) Legacy
     And the main heading is 'Transactions to be billed'
     And the user menu says I am signed in as 'Admin User'
     And I select 'Water Quality' from the Regime menu
+    And I select 'Imported Transaction Files' from the Transactions menu
+    And the main heading is 'Imported Transaction Files'
+    And the first record has file reference 'CFDAI00394'
     And I select 'Transactions to be billed' from the Transactions menu
+    And the main heading is 'Transactions to be billed'
     And I log the number of transactions displayed
     # If the TCM had no transactions the legacy test would then skip approx 600 lines of testing!
     # We've assumed we'll always be running this against an environment that at least has our basic test data. We will
@@ -33,15 +37,53 @@ Feature: CFD (Water Quality) Legacy
     Then I click the column title 'Period' and it sorts the transactions in ascending order
     Then I click the column title 'Category' and it sorts the transactions in ascending order
     Then I click the column title 'Category' and it sorts the transactions in descending order
-    Then I copy the consent reference from the first transaction
-    And search transactions with it
-    And all transactions displayed have the same consent reference
-    Then I select a category for the first transaction
-    And the transaction category will be set
-    And the transaction charge will be set
+    Then I set the temporary cessation flag for the first transaction
     Then I open the transaction detail page for the first transaction
     And the main heading is 'Transaction detail'
     And the sub heading 'Suggested category' is visible
+    And the sub heading 'Related unbilled transactions' is visible
     Then I open the transaction history page
     And the main heading is 'Transaction change history'
     And the first event is Transaction imported from file
+    Then I go back using the link
+    And exclude the transaction
+    And reinstate the transaction
+    Then I go back using the link
+    Then I go back using the link
+    Then I go back using the link
+    Then I click the export button and check the export modal displays
+    Then I copy the consent reference from the first transaction
+    And search transactions with it
+    And all transactions displayed have the same consent reference
+    Then I select a category for each transaction
+    And the transaction categories will be set
+    And the transaction charges will be set
+    And approve the transactions for billing
+    And generate the transaction file
+    Then I see confirmation the transaction file is queued for export
+    And there are no transactions to be billed displayed anymore
+    And I select 'Transaction File History' from the Transactions menu
+    And the main heading is 'Transaction File History'
+    And I set region to A
+    And I set pre post-sroc to Post
+    And I select 'Excluded Transactions' from the Transactions menu
+    And the main heading is 'Excluded Transactions'
+    Then I click the export button and check the export modal displays
+    And I select 'Transaction History' from the Transactions menu
+    And the main heading is 'Transaction History'
+    Then I click the export button and check the export modal displays
+    Then I set view to 'Pre-April 2018 Transactions to be billed'
+    And the main heading is 'Pre-April 2018 Transactions to be billed'
+    # At this point in the legacy tests we set the region, clear the search field and then hit search. But with an
+    # automates test this does nothing. Region A is already selected and the search field is already empty. So, clicking
+    # search is the equivalent of just doing a page refresh. So, we've omitted the clear and search but left the region
+    # selection for kicks!
+    And I set retrospectives region to A
+    And I grab the first record and confirm its period is pre-April 2018
+    Then I click the export button and check the export modal displays
+    Then I generate the pre-sroc transaction file
+    Then I see confirmation the transaction file is queued for export
+    # The section that checked downloading transaction data was commented out in the legacy test.
+    And I select 'Download Transaction Data' from the Transactions menu
+    And the main heading is 'Download Transaction Data'
+    And I confirm the data protection notice is displayed

--- a/cypress/integration/legacy/cfd.feature
+++ b/cypress/integration/legacy/cfd.feature
@@ -1,0 +1,47 @@
+@wip
+Feature: CFD (Water Quality) Legacy
+
+  Background:
+    Given I sign in as the admin user
+
+  Scenario: Legacy test
+    Then the user menu is visible
+    And the main heading is 'Transactions to be billed'
+    And the user menu says I am signed in as 'Admin User'
+    And I select 'Water Quality' from the Regime menu
+    And I select 'Transactions to be billed' from the Transactions menu
+    And I log the number of transactions displayed
+    # If the TCM had no transactions the legacy test would then skip approx 600 lines of testing!
+    # We've assumed we'll always be running this against an environment that at least has our basic test data. We will
+    # always attempt to run the following steps.
+    And I log which region is selected in the search bar
+    And I select All for financial year in the search bar
+    And I select 50 for items per page in the paging info bar
+    Then I click the column title 'File Reference' and it sorts the transactions in ascending order
+    Then I click the column title 'File Reference' and it sorts the transactions in descending order
+    Then I click the column title 'File Date' and it sorts the transactions in descending order
+    Then I click the column title 'File Date' and it sorts the transactions in ascending order
+    Then I click the column title 'Customer' and it sorts the transactions in ascending order
+    Then I click the column title 'Customer' and it sorts the transactions in descending order
+    Then I click the column title 'Consent' and it sorts the transactions in descending order
+    Then I click the column title 'Consent' and it sorts the transactions in ascending order
+    And I see the 'Ver' column is displayed
+    And I see the 'Dis' column is displayed
+    Then I click the column title '%' and it sorts the transactions in ascending order
+    Then I click the column title '%' and it sorts the transactions in descending order
+    Then I click the column title 'Period' and it sorts the transactions in descending order
+    Then I click the column title 'Period' and it sorts the transactions in ascending order
+    Then I click the column title 'Category' and it sorts the transactions in ascending order
+    Then I click the column title 'Category' and it sorts the transactions in descending order
+    Then I copy the consent reference from the first transaction
+    And search transactions with it
+    And all transactions displayed have the same consent reference
+    Then I select a category for the first transaction
+    And the transaction category will be set
+    And the transaction charge will be set
+    Then I open the transaction detail page for the first transaction
+    And the main heading is 'Transaction detail'
+    And the sub heading 'Suggested category' is visible
+    Then I open the transaction history page
+    And the main heading is 'Transaction change history'
+    And the first event is Transaction imported from file

--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -1,0 +1,196 @@
+// We disable this rule to prevent chai matchers like `to.be.empty` causing linting errors:
+/* eslint-disable no-unused-expressions */
+
+import { Given, Then, And, Before } from 'cypress-cucumber-preprocessor/steps'
+import MainMenu from '../../../pages/menus/main_menu'
+import SignInPage from '../../../pages/sign_in_page'
+import TransactionsPage from '../../../pages/transactions_page'
+
+Before(() => {
+  // When certain drop downs are selected the TCM will do a background refresh of the UI using XHR requests.
+  // The impact on testing is that there are times having selected an option we need to wait for that background request
+  // to complete before we then try and get() or assert anything in the UI. If we don't we may get old data or hit
+  // inexplicable Cypress errors.
+  //
+  // The legacy tests handled this by scattering wait() calls all over the place. However, most testing frameworks
+  // consider this an anti-pattern https://docs.cypress.io/guides/references/best-practices#Unnecessary-Waiting. The
+  // solution in Cypress is to intercept requests, register an alias for them and then when needed wait() on a
+  // registered alias (XHR request) to complete. We do the intercept part in a before() hook as there are a number of
+  // steps that depend on selecting dropdowns in the UI
+  cy.intercept('GET', '**?search=*').as('getSearch')
+
+  // This request is made when a transaction is selected from the results
+  cy.intercept('GET', '**/regimes/*/transactions/*').as('getTransaction')
+
+  // This request is made from the transaction detail page to view its history
+  cy.intercept('GET', '**/transactions/*/audit').as('getTransactionHistory')
+})
+
+Given('I sign in as the {word} user', (regime) => {
+  SignInPage.visit()
+  SignInPage.email().type(Cypress.config().users[regime].email)
+  SignInPage.password().type(Cypress.env('PASSWORD'))
+
+  SignInPage.logIn().click()
+})
+
+Then('the user menu is visible', () => {
+  MainMenu.user.menuLink().should('be.visible')
+})
+
+And('the main heading is {string}', (heading) => {
+  cy.get('h1').should('contain', heading)
+})
+
+And('the user menu says I am signed in as {string}', (username) => {
+  MainMenu.user.menuLink().should('contain', username)
+})
+
+And('I select {string} from the Regime menu', (optionText) => {
+  MainMenu.regime.getOption(optionText).click()
+})
+
+And('I select {string} from the Transactions menu', (optionText) => {
+  MainMenu.transactions.getOption(optionText, 'cfd').click()
+})
+
+And('I log the number of transactions displayed', () => {
+  TransactionsPage.resultsTable().find('tbody').find('tr').then((rows) => {
+    cy.log(`Number of transactions listed is ${rows.length}`)
+  })
+})
+
+And('I log which region is selected in the search bar', () => {
+  cy.get('select#region').find(':selected').invoke('text').then((text) => {
+    cy.log(`Region selected for search is ${text}`)
+  })
+})
+
+And('I select {word} for financial year in the search bar', (option) => {
+  cy.get('select#fy').select(option)
+
+  cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
+
+  cy.get('select#fy').find(':selected').invoke('text').then((val) => {
+    expect(val).to.equal(option)
+  })
+})
+
+And('I select {word} for items per page in the paging info bar', (option) => {
+  cy.get('select#per_page').select(option)
+
+  cy.wait('@getSearch')
+
+  cy.get('select#per_page').find(':selected').invoke('text').then((val) => {
+    expect(val).to.equal(option)
+  })
+})
+
+Then('I click the column title {string} and it sorts the transactions in {word} order', (sort, sortOrder) => {
+  const sorts = {
+    'File Reference': 'file_reference',
+    'File Date': 'file_date',
+    Customer: 'customer_reference',
+    Consent: 'consent_reference',
+    Category: 'sroc_category',
+    '%': 'variation',
+    Period: 'period'
+  }
+
+  const sortOrders = {
+    ascending: 'oi-caret-top',
+    descending: 'oi-caret-bottom'
+  }
+
+  cy.get(`th > [data-column="${sorts[sort]}"]`).click()
+
+  cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
+
+  cy.get(`th > [data-column="${sorts[sort]}"]`).then((element) => {
+    expect(element).to.have.class('sorted')
+    expect(element.find('span.oi')).to.have.class(sortOrders[sortOrder])
+  })
+})
+
+Then('I see the {string} column is displayed', (columnName) => {
+  cy.get('span[aria-hidden="true"]').contains(columnName).then((element) => {
+    expect(element).to.be.visible
+  })
+})
+
+Then('I copy the consent reference from the first transaction', () => {
+  cy.get('.table-responsive > tbody > tr:first-child > td').eq(4).invoke('text').then((reference) => {
+    cy.wrap(reference.trim()).as('searchValue')
+  })
+})
+
+And('search transactions with it', () => {
+  cy.get('@searchValue').then((searchValue) => {
+    cy.get('#search').type(searchValue)
+    cy.get('input[value="Search"]').click()
+
+    cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
+  })
+})
+
+And('all transactions displayed have the same consent reference', () => {
+  cy.get('@searchValue').then((searchValue) => {
+    cy.get('.table-responsive > tbody > tr').each((element) => {
+      expect(element.children('td:nth-child(5)').text().trim()).to.equal(searchValue)
+    })
+  })
+})
+
+Then('I select a category for the first transaction', () => {
+  cy.get('.table-responsive > tbody > tr:first-child input.tcm-select-input').type('{downarrow}')
+  cy.get('.table-responsive > tbody > tr:first-child input.tcm-select-input').type('{enter}')
+
+  cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
+})
+
+And('the transaction category will be set', () => {
+  cy.get('.table-responsive > tbody > tr:first-child input.tcm-select-input').should('not.exist')
+  cy.get('.table-responsive > tbody > tr:first-child > td').eq(7).invoke('text').then((reference) => {
+    expect(reference.trim()).not.to.be.undefined
+  })
+})
+
+And('the transaction charge will be set', () => {
+  cy.get('.table-responsive > tbody > tr:first-child > td').eq(12).invoke('text').then((reference) => {
+    expect(reference.trim()).not.to.contain('(TBC)')
+  })
+})
+
+Then('I open the transaction detail page for the first transaction', () => {
+  cy.get('tbody > tr:first-child button.show-details-button').click()
+
+  cy.wait('@getTransaction').its('response.statusCode').should('eq', 200)
+})
+
+And('the sub heading {string} is visible', (heading) => {
+  cy.get('h2')
+    .should('contain', heading)
+    .should('be.visible')
+})
+
+Then('I open the transaction history page', () => {
+  cy.get('a.btn-outline-info').click()
+
+  cy.wait('@getTransactionHistory')
+})
+
+And('the first event is Transaction imported from file', () => {
+  cy.get('tbody > tr:first-child > td:first-child').should('contain.text', 'Transaction imported from file')
+})
+
+Then('the {word} element is visible', (selector) => {
+  cy.get(selector).should('be.visible')
+})
+
+And('the {word} element contains {string}', (selector, text) => {
+  cy.get(selector).should('contain', text)
+})
+
+And('I click the element {string}', (selector) => {
+  cy.get(selector).click()
+})

--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -17,13 +17,28 @@ Before(() => {
   // solution in Cypress is to intercept requests, register an alias for them and then when needed wait() on a
   // registered alias (XHR request) to complete. We do the intercept part in a before() hook as there are a number of
   // steps that depend on selecting dropdowns in the UI
-  cy.intercept('GET', '**?search=*').as('getSearch')
+  cy.intercept('GET', '**/regimes/*/transactions?search=*').as('getSearch')
 
   // This request is made when a transaction is selected from the results
   cy.intercept('GET', '**/regimes/*/transactions/*').as('getTransaction')
 
   // This request is made from the transaction detail page to view its history
   cy.intercept('GET', '**/transactions/*/audit').as('getTransactionHistory')
+
+  // This request is made when the 'Approve' button is clicked
+  cy.intercept('PUT', '**/regimes/*/transactions/approve.json').as('putApproveTransactions')
+
+  // This request is made just before displaying the generate transaction file summary modal
+  cy.intercept('GET', '**/regimes/*/transaction_summary?**').as('getTransactionSummary')
+
+  // This request is made in transaction file history after search criteria have been selected
+  cy.intercept('GET', '**/regimes/*/transaction_files?search**').as('getTransactionFileHistory')
+
+  // This request is made in transaction  history after changing the view option
+  cy.intercept('GET', '**/regimes/*/retrospectives?*').as('getRetrospectivesSearch')
+
+  // This request is made just before displaying the generate presroc transaction file summary modal
+  cy.intercept('GET', '**/regimes/*/retrospective_summary?**').as('getRetrospectiveSummary')
 })
 
 Given('I sign in as the {word} user', (regime) => {
@@ -54,6 +69,12 @@ And('I select {string} from the Transactions menu', (optionText) => {
   MainMenu.transactions.getOption(optionText, 'cfd').click()
 })
 
+Then('the first record has file reference {string}', (fileReference) => {
+  cy.get('.table-responsive > tbody > tr:first-child > td').eq(1).invoke('text').then((reference) => {
+    expect(reference.trim()).to.equal(fileReference)
+  })
+})
+
 And('I log the number of transactions displayed', () => {
   TransactionsPage.resultsTable().find('tbody').find('tr').then((rows) => {
     cy.log(`Number of transactions listed is ${rows.length}`)
@@ -79,7 +100,7 @@ And('I select {word} for financial year in the search bar', (option) => {
 And('I select {word} for items per page in the paging info bar', (option) => {
   cy.get('select#per_page').select(option)
 
-  cy.wait('@getSearch')
+  cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
 
   cy.get('select#per_page').find(':selected').invoke('text').then((val) => {
     expect(val).to.equal(option)
@@ -134,6 +155,10 @@ And('search transactions with it', () => {
 })
 
 And('all transactions displayed have the same consent reference', () => {
+  // This line is here to force Cypress to wait until the search is complete. Cypress should() has an inbuilt retry
+  // mechanism. We know it takes a moment for the UI to update with the results and during that time it has the Search
+  // button disable. We use this information to wait until the button is enabled before then grabbing all the table rows
+  cy.get('input[value="Search"]').should('not.have.attr', 'disabled')
   cy.get('@searchValue').then((searchValue) => {
     cy.get('.table-responsive > tbody > tr').each((element) => {
       expect(element.children('td:nth-child(5)').text().trim()).to.equal(searchValue)
@@ -141,23 +166,29 @@ And('all transactions displayed have the same consent reference', () => {
   })
 })
 
-Then('I select a category for the first transaction', () => {
-  cy.get('.table-responsive > tbody > tr:first-child input.tcm-select-input').type('{downarrow}')
-  cy.get('.table-responsive > tbody > tr:first-child input.tcm-select-input').type('{enter}')
+Then('I select a category for each transaction', () => {
+  cy.get('.table-responsive > tbody > tr input.tcm-select-input').each((element, index) => {
+    cy.get('.table-responsive > tbody > tr:nth-child(1) input.tcm-select-input').type('{downarrow}')
+    cy.get('.table-responsive > tbody > tr:nth-child(1) input.tcm-select-input').type('{enter}')
+    cy.wait('@getSearch')
+    cy.wait(500)
+  })
 
-  cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
+  cy.wait(500)
 })
 
-And('the transaction category will be set', () => {
-  cy.get('.table-responsive > tbody > tr:first-child input.tcm-select-input').should('not.exist')
-  cy.get('.table-responsive > tbody > tr:first-child > td').eq(7).invoke('text').then((reference) => {
-    expect(reference.trim()).not.to.be.undefined
+And('the transaction categories will be set', () => {
+  cy.get('.table-responsive > tbody > tr').each((element, index) => {
+    cy.get(`.table-responsive > tbody > tr:nth-child(${index + 1}) input.tcm-select-input`).should('not.exist')
+    cy.get(`.table-responsive > tbody > tr:nth-child(${index + 1}) td`).eq(7).invoke('text').then((reference) => {
+      expect(reference.trim()).not.to.be.undefined
+    })
   })
 })
 
-And('the transaction charge will be set', () => {
-  cy.get('.table-responsive > tbody > tr:first-child > td').eq(12).invoke('text').then((reference) => {
-    expect(reference.trim()).not.to.contain('(TBC)')
+And('the transaction charges will be set', () => {
+  cy.get('.table-responsive > tbody > tr').each((element, index) => {
+    cy.get(`.table-responsive > tbody > tr:nth-child(${index + 1}) td`).eq(12).should('not.contain.text', '(TBC)')
   })
 })
 
@@ -165,6 +196,10 @@ Then('I open the transaction detail page for the first transaction', () => {
   cy.get('tbody > tr:first-child button.show-details-button').click()
 
   cy.wait('@getTransaction').its('response.statusCode').should('eq', 200)
+})
+
+Then('there are no transactions to be billed displayed anymore', () => {
+  cy.get('.table-responsive > tbody > tr').should('not.exist')
 })
 
 And('the sub heading {string} is visible', (heading) => {
@@ -176,21 +211,167 @@ And('the sub heading {string} is visible', (heading) => {
 Then('I open the transaction history page', () => {
   cy.get('a.btn-outline-info').click()
 
-  cy.wait('@getTransactionHistory')
+  cy.wait('@getTransactionHistory').its('response.statusCode').should('eq', 200)
 })
 
 And('the first event is Transaction imported from file', () => {
   cy.get('tbody > tr:first-child > td:first-child').should('contain.text', 'Transaction imported from file')
 })
 
-Then('the {word} element is visible', (selector) => {
-  cy.get(selector).should('be.visible')
+Then('I go back using the link', () => {
+  cy.get('.back-link').click()
 })
 
-And('the {word} element contains {string}', (selector, text) => {
-  cy.get(selector).should('contain', text)
+Then('I click the export button and check the export modal displays', () => {
+  cy.get('button.table-export-btn').click()
+  // NOTE: Whilst handy to confirm the dialog has appeared this is actually here to force the tests to wait for the
+  // dialog until it then tries to get() elements on it
+  cy.get('#data-protection-dialog')
+    .should('have.class', 'show')
+    .should('have.attr', 'aria-modal')
+  cy.get('#data-protection-dialog').should('not.have.attr', 'aria-hidden')
+
+  cy.get('#data-protection-dialog h5.modal-title')
+    .should('be.visible')
+    .should('contain.text', 'Export Transaction Data')
+
+  // TODO: Understand why we need this explicit wait() here. We've confirmed that the modal dialog is open
+  // and visible and that we can access the controls. But without this wait() we find more often than not the
+  // dialog is not dismissed when cancel is clicked which causes an error in the tests
+  cy.wait(500)
+
+  cy.get('#data-protection-dialog button.btn[data-dismiss="modal"]')
+    .should('be.visible')
+    .click()
 })
 
-And('I click the element {string}', (selector) => {
-  cy.get(selector).click()
+Then('I set the temporary cessation flag for the first transaction', () => {
+  cy.get('.table-responsive > tbody > tr:first-child select.temporary-cessation-select').select('Y').should('have.value', 'true')
+})
+
+And('exclude the transaction', () => {
+  cy.get('button.exclude-button').click()
+  cy.get('input[type="submit"][data-disable-with="Exclude Transaction"]').click()
+  cy.get('span.badge-danger').should('contain.text', 'Marked for Exclusion')
+})
+
+And('reinstate the transaction', () => {
+  cy.get('input[type="submit"][data-disable-with="Reinstate for Billing"]').click()
+  cy.get('button.exclude-button').should('be.visible')
+
+  cy.wait('@getTransaction').its('response.statusCode').should('eq', 200)
+})
+
+And('approve the transactions for billing', () => {
+  cy.get('button.approve-all-btn').click()
+
+  cy.wait('@putApproveTransactions')
+  cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
+  cy.wait(500)
+})
+
+And('generate the transaction file', () => {
+  cy.get('button.generate-transaction-file-btn').click()
+
+  cy.wait('@getTransactionSummary').its('response.statusCode').should('eq', 200)
+  cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
+
+  // NOTE: Whilst handy to confirm the dialog has appeared this is actually here to force the tests to wait for the
+  // dialog until it then tries to get() elements on it
+  cy.get('#summary-dialog')
+    .should('have.class', 'show')
+    .should('have.attr', 'aria-modal')
+  cy.get('#summary-dialog').should('not.have.attr', 'aria-hidden')
+
+  cy.get('#summary-dialog h5.modal-title')
+    .should('be.visible')
+    .should('contain.text', 'Generate Transaction File')
+
+  // TODO: Understand why we need this explicit wait() here. We've confirmed that the modal dialog is open
+  // and visible and that we can access the controls. But without this wait() we find more often than not the
+  // dialog is not dismissed when cancel is clicked which causes an error in the tests
+  cy.wait(500)
+
+  cy.get('#summary-dialog input#confirm').check()
+
+  cy.get('#summary-dialog input.file-generate-btn')
+    .should('be.enabled')
+    .click()
+
+  // cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
+})
+
+Then('I see confirmation the transaction file is queued for export', () => {
+  cy.get('div.alert-success.alert-dismissable').should('contain.text', 'Successfully queued')
+})
+
+And('I set region to {word}', (option) => {
+  cy.get('select#region').select(option)
+
+  cy.wait('@getTransactionFileHistory').its('response.statusCode').should('eq', 200)
+})
+
+And('I set retrospectives region to {word}', (option) => {
+  cy.get('select#region').select(option)
+
+  cy.wait('@getRetrospectivesSearch').its('response.statusCode').should('eq', 200)
+})
+
+And('I set pre post-sroc to {word}', (option) => {
+  cy.get('select#prepost').select(option)
+
+  cy.wait('@getTransactionFileHistory').its('response.statusCode').should('eq', 200)
+})
+
+Then('I set view to {string}', (option) => {
+  cy.get('select#mode').select(option)
+
+  cy.wait('@getRetrospectivesSearch').its('response.statusCode').should('eq', 200)
+})
+
+And('I grab the first record and confirm its period is pre-April 2018', () => {
+  cy.get('.table-responsive > tbody > tr:first-child td').eq(8).invoke('text').then((text) => {
+    const endPeriod = text.trim().slice(11)
+    const parts = endPeriod.split('/')
+    const year = parseInt(parts[2])
+    cy.log(`Extracted period end year is ${year}`)
+
+    expect(year).to.be.at.most(18)
+  })
+})
+
+Then('I generate the pre-sroc transaction file', () => {
+  cy.get('button.generate-transaction-file-btn').click()
+
+  cy.wait('@getRetrospectiveSummary').its('response.statusCode').should('eq', 200)
+
+  // NOTE: Whilst handy to confirm the dialog has appeared this is actually here to force the tests to wait for the
+  // dialog until it then tries to get() elements on it
+  cy.get('#summary-dialog')
+    .should('have.class', 'show')
+    .should('have.attr', 'aria-modal')
+  cy.get('#summary-dialog').should('not.have.attr', 'aria-hidden')
+
+  cy.get('#summary-dialog h5.modal-title')
+    .should('be.visible')
+    .should('contain.text', 'Generate Pre-SRoC File')
+
+  // TODO: Understand why we need this explicit wait() here. We've confirmed that the modal dialog is open
+  // and visible and that we can access the controls. But without this wait() we find more often than not the
+  // dialog is not dismissed when cancel is clicked which causes an error in the tests
+  cy.wait(500)
+
+  cy.get('#summary-dialog input#confirm').check()
+
+  cy.get('#summary-dialog input.file-generate-btn')
+    .should('be.enabled')
+    .click()
+
+  cy.wait('@getRetrospectivesSearch').its('response.statusCode').should('eq', 200)
+})
+
+And('I confirm the data protection notice is displayed', () => {
+  cy.get('.card-header')
+    .should('contain', 'Data Protection Notice')
+    .should('be.visible')
 })

--- a/cypress/pages/menus/main_menu.js
+++ b/cypress/pages/menus/main_menu.js
@@ -1,0 +1,19 @@
+import RegimeMenu from './regime_menu'
+import TransactionsMenu from './transactions_menu'
+import UserMenu from './user_menu'
+
+class MainMenu {
+  static get regime () {
+    return RegimeMenu
+  }
+
+  static get transactions () {
+    return TransactionsMenu
+  }
+
+  static get user () {
+    return UserMenu
+  }
+}
+
+export default MainMenu

--- a/cypress/pages/menus/regime_menu.js
+++ b/cypress/pages/menus/regime_menu.js
@@ -1,0 +1,25 @@
+class RegimeMenu {
+  static get options () {
+    return {
+      Installations: '[href="/regimes/pas/transactions"]',
+      Waste: '[href="/regimes/pas/transactions"]',
+      'Water Quality': '[href="/regimes/cfd/transactions"]'
+    }
+  }
+
+  static get selector () {
+    return '[aria-labelledby="navbarRegimeSelectorLink"]'
+  }
+
+  static menuLink () {
+    return cy.get('#navbarRegimeSelectorLink')
+  }
+
+  static getOption (optionText) {
+    this.menuLink().click()
+
+    return cy.get(`${this.selector} > ${this.options[optionText]}`)
+  }
+}
+
+export default RegimeMenu

--- a/cypress/pages/menus/transactions_menu.js
+++ b/cypress/pages/menus/transactions_menu.js
@@ -6,7 +6,7 @@ class TransactionsMenu {
   static options (regimeSlug) {
     return {
       'Transactions to be billed': `[href="/regimes/${regimeSlug}/transactions"]`,
-      'Transaction History': `[href="/regimes/${regimeSlug}/transactions"]`,
+      'Transaction History': `[href="/regimes/${regimeSlug}/history"]`,
       'Pre-April 2018 Transactions to be billed': `[href="/regimes/${regimeSlug}/retrospectives"]`,
       'Excluded Transactions': `[href="/regimes/${regimeSlug}/exclusions"]`,
       'Imported Transaction Files': `[href="/regimes/${regimeSlug}/imported_transaction_files"]`,

--- a/cypress/pages/menus/transactions_menu.js
+++ b/cypress/pages/menus/transactions_menu.js
@@ -1,0 +1,29 @@
+class TransactionsMenu {
+  static get selector () {
+    return '[aria-labelledby="navbarTransactionsSelectorLink"]'
+  }
+
+  static options (regimeSlug) {
+    return {
+      'Transactions to be billed': `[href="/regimes/${regimeSlug}/transactions"]`,
+      'Transaction History': `[href="/regimes/${regimeSlug}/transactions"]`,
+      'Pre-April 2018 Transactions to be billed': `[href="/regimes/${regimeSlug}/retrospectives"]`,
+      'Excluded Transactions': `[href="/regimes/${regimeSlug}/exclusions"]`,
+      'Imported Transaction Files': `[href="/regimes/${regimeSlug}/imported_transaction_files"]`,
+      'Transaction File History': `[href="/regimes/${regimeSlug}/transaction_files"]`,
+      'Download Transaction Data': `[href="/regimes/${regimeSlug}/data_export"]`
+    }
+  }
+
+  static menuLink () {
+    return cy.get('#navbarTransactionsSelectorLink')
+  }
+
+  static getOption (optionText, regimeSlug) {
+    this.menuLink().click()
+
+    return cy.get(`${this.selector} > ${this.options(regimeSlug)[optionText]}`)
+  }
+}
+
+export default TransactionsMenu

--- a/cypress/pages/menus/user_menu.js
+++ b/cypress/pages/menus/user_menu.js
@@ -1,0 +1,24 @@
+class UserMenu {
+  static get options () {
+    return {
+      'Change Password': '[href="/change_password/edit"]',
+      'Sign out': '[href="/auth/sign_out"]'
+    }
+  }
+
+  static get selector () {
+    return '[aria-labelledby="navbarUserMenuLink"]'
+  }
+
+  static menuLink () {
+    return cy.get('#navbarUserMenuLink')
+  }
+
+  static getOption (optionText) {
+    this.menuLink().click()
+
+    return cy.get(`${this.selector} > ${this.options[optionText]}`)
+  }
+}
+
+export default UserMenu

--- a/cypress/pages/transactions_page.js
+++ b/cypress/pages/transactions_page.js
@@ -70,6 +70,10 @@ class TransactionsPage {
   static reviewAnnualBillingDataMenuItem () {
     return cy.get(':nth-child(1) > .dropdown > div > [href="/regimes/wml/annual_billing_data_files"]')
   }
+
+  static regionDropDown () {
+    return cy.get('#region')
+  }
 }
 
 export default TransactionsPage


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-264

The [SROC TCM Acceptance tests](https://github.com/DEFRA/sroc-tcm-acceptance-tests) is actually a single Selenium-based test that goes through the TCM checking it for each of the 3 regimes. It was what the current team were handed and is currently the most extensive test of the TCM service.

However, it is impossible to maintain and hard to follow what the test is actually doing. What we do know of it is that there are no assertions. The test assumes if it can click through with no errors the TCM is functioning correctly. But we have had examples where this is not the case.

This change migrates what the legacy test is doing for the Water Quality (CFD) regime into our Cypress framework. Re-writing the test in BDD format should make it easier to understand what actions are being taken. From there we can review the test, breaking it down into valuable features we can maintain going forward.