### PR TITLE
Housekeeping - Update dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.35.0",
-        "@faker-js/faker": "^6.0.0-alpha.7",
+        "@aws-sdk/client-s3": "^3.55.0",
+        "@faker-js/faker": "^6.0.0",
         "cucumber-html-reporter": "^5.5.0",
-        "cypress": "^8.3.1",
-        "cypress-cucumber-preprocessor": "^4.2.0",
-        "cypress-dotenv": "^1.2.2",
-        "dotenv": "^8.2.0",
+        "cypress": "^9.5.2",
+        "cypress-cucumber-preprocessor": "^4.3.1",
+        "cypress-dotenv": "^2.0.0",
+        "dotenv": "^16.0.0",
         "path": "^0.12.7"
       },
       "devDependencies": {
-        "standard": "^16.0.3"
+        "standard": "^16.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3240,9 +3240,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
-      "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
+      "version": "2.88.10",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+      "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -3251,8 +3251,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
+        "http-signature": "~1.3.6",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
@@ -3308,9 +3307,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "6.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0-alpha.7.tgz",
-      "integrity": "sha512-T2nYE8+EfzfkRMLMSm7UvgC7fZ2KkKEyCMeyPVS0q2cuvENbt1SjWyu0bOJ0JqBbTs1g+gYMWMFMXspWlzNVmQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0.tgz",
+      "integrity": "sha512-10zLCKhp3YEmBuko71ivcMoIZcCLXgQVck6aNswX+AWwaek/L8S3yz9i8m3tHigRkcF6F2vI+qtdtyySHK+bGA==",
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=7.0.0"
@@ -3361,9 +3360,9 @@
       "integrity": "sha512-gI5Sl30tmhXsqkNvopFydP7ASc4c2cLfGNQrVKN3X90ADFWFsPEsotm/8JHSUJQKTHbwowAHtcJPeyVhtKv0TQ=="
     },
     "node_modules/@types/sinonjs__fake-timers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg=="
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g=="
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.2",
@@ -3450,6 +3449,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3620,9 +3620,9 @@
       }
     },
     "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -4191,7 +4191,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -4279,11 +4278,14 @@
       }
     },
     "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4447,18 +4449,17 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
-      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dependencies": {
-        "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
       "engines": {
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "colors": "^1.1.2"
+        "colors": "1.4.0"
       }
     },
     "node_modules/cli-truncate": {
@@ -5198,24 +5199,25 @@
       }
     },
     "node_modules/cypress": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.7.0.tgz",
-      "integrity": "sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.2.tgz",
+      "integrity": "sha512-gYiQYvJozMzDOriUV1rCt6CeRM/pRK4nhwGJj3nJQyX2BoUdTCVwp30xDMKc771HiNVhBtgj5o5/iBdVDVXQUg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.6",
+        "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.0",
+        "cli-table3": "~0.6.1",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -5238,12 +5240,11 @@
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
-        "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "bin": {
@@ -5307,29 +5308,20 @@
       }
     },
     "node_modules/cypress-dotenv": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cypress-dotenv/-/cypress-dotenv-1.2.3.tgz",
-      "integrity": "sha512-9TsM0iy21Js0muRqNEBvMaIJpx2jRR6HtFuSJXJFacxrGZnnFqzl+TiOOlquIcqGxIzPTFKOLztWMAP2qU21qw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-dotenv/-/cypress-dotenv-2.0.0.tgz",
+      "integrity": "sha512-MHCkWuTU51n/Q6LT2FgjNVZx/OmnrP3Jve7TUGZvSbjgGOpBOVZTbm3tomjvn+2S6HhloRXSAOmT5fY9pvWkpQ==",
       "dependencies": {
-        "camelcase": "^5.3.1",
-        "dotenv-parse-variables": "^0.2.3",
-        "lodash.clonedeep": "^2.0.0"
+        "camelcase": "^6.2.0",
+        "dotenv-parse-variables": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
       },
       "engines": {
-        "node": ">=8.x"
+        "node": ">=10.x"
       },
       "peerDependencies": {
-        "cypress": ">= 3.x",
-        "dotenv": "8.x"
-      }
-    },
-    "node_modules/cypress-dotenv/node_modules/lodash.clonedeep": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-2.4.1.tgz",
-      "integrity": "sha1-8pIDtAsS/uCkXTYxZIJZvrq8eGg=",
-      "dependencies": {
-        "lodash._baseclone": "~2.4.1",
-        "lodash._basecreatecallback": "~2.4.1"
+        "cypress": ">= 8.x",
+        "dotenv": ">= 10.x"
       }
     },
     "node_modules/cypress/node_modules/supports-color": {
@@ -5549,22 +5541,23 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dotenv-parse-variables": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv-parse-variables/-/dotenv-parse-variables-0.2.3.tgz",
-      "integrity": "sha512-cuog/uu2sD6AGTExLldBqN4kUWNjGG86cSpYGYgZrzgSiy37HkB3OOpMv7cTiQ7SKCMu8WryUS9P6lqwrh0pLg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-parse-variables/-/dotenv-parse-variables-2.0.0.tgz",
+      "integrity": "sha512-/Tezlx6xpDqR6zKg1V4vLCeQtHWiELhWoBz5A/E0+A1lXN9iIkNbbfc4THSymS0LQUo8F1PMiIwVG8ai/HrnSA==",
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1",
+        "is-string-and-not-blank": "^0.0.2"
       },
       "engines": {
-        "node": ">= 6.x"
+        "node": ">= 8.3.0"
       }
     },
     "node_modules/duplexer2": {
@@ -6345,12 +6338,14 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -6798,27 +6793,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6961,17 +6935,16 @@
       }
     },
     "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
       "dependencies": {
         "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.14.1"
       },
       "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
+        "node": ">=0.10"
       }
     },
     "node_modules/https-browserify": {
@@ -7373,6 +7346,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-string-and-not-blank": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/is-string-and-not-blank/-/is-string-and-not-blank-0.0.2.tgz",
+      "integrity": "sha512-FyPGAbNVyZpTeDCTXnzuwbu9/WpNXbCfbHXLpCRpN4GANhS00eEIP5Ef+k5HYSNIzIhdN9zRDoBj6unscECvtQ==",
+      "dependencies": {
+        "is-string-blank": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
+    "node_modules/is-string-blank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
+    },
     "node_modules/is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -7511,14 +7500,15 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify": {
       "version": "0.0.1",
@@ -7596,16 +7586,16 @@
       }
     },
     "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
       "engines": [
         "node >=0.6.0"
       ],
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -7749,153 +7739,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash._arraypool": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
-      "integrity": "sha1-6I7suS4ruEyQZWEv2VigcZzUf5Q="
-    },
-    "node_modules/lodash._basebind": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
-      "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
-      "dependencies": {
-        "lodash._basecreate": "~2.4.1",
-        "lodash._setbinddata": "~2.4.1",
-        "lodash._slice": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._baseclone": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
-      "integrity": "sha1-MPgj5X4X43NdODvWK2Czh1Q7QYY=",
-      "dependencies": {
-        "lodash._getarray": "~2.4.1",
-        "lodash._releasearray": "~2.4.1",
-        "lodash._slice": "~2.4.1",
-        "lodash.assign": "~2.4.1",
-        "lodash.foreach": "~2.4.1",
-        "lodash.forown": "~2.4.1",
-        "lodash.isarray": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._basecreate": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-      "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
-      "dependencies": {
-        "lodash._isnative": "~2.4.1",
-        "lodash.isobject": "~2.4.1",
-        "lodash.noop": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._basecreatecallback": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
-      "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
-      "dependencies": {
-        "lodash._setbinddata": "~2.4.1",
-        "lodash.bind": "~2.4.1",
-        "lodash.identity": "~2.4.1",
-        "lodash.support": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._basecreatewrapper": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
-      "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
-      "dependencies": {
-        "lodash._basecreate": "~2.4.1",
-        "lodash._setbinddata": "~2.4.1",
-        "lodash._slice": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._createwrapper": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-      "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
-      "dependencies": {
-        "lodash._basebind": "~2.4.1",
-        "lodash._basecreatewrapper": "~2.4.1",
-        "lodash._slice": "~2.4.1",
-        "lodash.isfunction": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._getarray": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
-      "integrity": "sha1-+vH3+BD6mFolHCGHQESBCUg55e4=",
-      "dependencies": {
-        "lodash._arraypool": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._isnative": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
-    },
-    "node_modules/lodash._maxpoolsize": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz",
-      "integrity": "sha1-nUgvRjuOZq++WcLBTtsRcGAXIzQ="
-    },
-    "node_modules/lodash._objecttypes": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
-    },
-    "node_modules/lodash._releasearray": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
-      "integrity": "sha1-phOWMNdtFTawfdyAliiJsIL2pkE=",
-      "dependencies": {
-        "lodash._arraypool": "~2.4.1",
-        "lodash._maxpoolsize": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._setbinddata": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-      "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
-      "dependencies": {
-        "lodash._isnative": "~2.4.1",
-        "lodash.noop": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._shimkeys": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-      "dependencies": {
-        "lodash._objecttypes": "~2.4.1"
-      }
-    },
-    "node_modules/lodash._slice": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
-      "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8="
-    },
-    "node_modules/lodash.assign": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
-      "integrity": "sha1-hMOVlt1xGBqXsGUpE6fJZ15Jsao=",
-      "dependencies": {
-        "lodash._basecreatecallback": "~2.4.1",
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
-      }
-    },
-    "node_modules/lodash.bind": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
-      "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
-      "dependencies": {
-        "lodash._createwrapper": "~2.4.1",
-        "lodash._slice": "~2.4.1"
-      }
-    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -7906,70 +7749,10 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "node_modules/lodash.foreach": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
-      "integrity": "sha1-/j/Do0yGyUyrb5UiVgKCdB4BYwk=",
-      "dependencies": {
-        "lodash._basecreatecallback": "~2.4.1",
-        "lodash.forown": "~2.4.1"
-      }
-    },
-    "node_modules/lodash.forown": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
-      "integrity": "sha1-eLQer+FAX6lmRZ6kGT/VAtCEUks=",
-      "dependencies": {
-        "lodash._basecreatecallback": "~2.4.1",
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
-      }
-    },
-    "node_modules/lodash.identity": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
-      "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE="
-    },
-    "node_modules/lodash.isarray": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
-      "integrity": "sha1-tSoybB9i9tfac6MdVAHfbvRPD6E=",
-      "dependencies": {
-        "lodash._isnative": "~2.4.1"
-      }
-    },
-    "node_modules/lodash.isfunction": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
-      "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE="
-    },
-    "node_modules/lodash.isobject": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-      "dependencies": {
-        "lodash._objecttypes": "~2.4.1"
-      }
-    },
-    "node_modules/lodash.keys": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-      "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-      "dependencies": {
-        "lodash._isnative": "~2.4.1",
-        "lodash._shimkeys": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
     "node_modules/lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
-    },
-    "node_modules/lodash.noop": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
-      "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -7993,14 +7776,6 @@
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
       "peer": true
-    },
-    "node_modules/lodash.support": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
-      "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
-      "dependencies": {
-        "lodash._isnative": "~2.4.1"
-      }
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -8159,19 +7934,19 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": {
-        "mime-db": "1.49.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -9133,9 +8908,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "engines": {
         "node": ">=0.6"
       }
@@ -9156,11 +8931,6 @@
       "engines": {
         "node": ">=0.4.x"
       }
-    },
-    "node_modules/ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -9513,7 +9283,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -9721,9 +9490,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "node_modules/sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -10487,6 +10256,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -13605,9 +13375,9 @@
       }
     },
     "@cypress/request": {
-      "version": "2.88.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
-      "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
+      "version": "2.88.10",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+      "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -13616,8 +13386,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
+        "http-signature": "~1.3.6",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
@@ -13668,9 +13437,9 @@
       }
     },
     "@faker-js/faker": {
-      "version": "6.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0-alpha.7.tgz",
-      "integrity": "sha512-T2nYE8+EfzfkRMLMSm7UvgC7fZ2KkKEyCMeyPVS0q2cuvENbt1SjWyu0bOJ0JqBbTs1g+gYMWMFMXspWlzNVmQ=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0.tgz",
+      "integrity": "sha512-10zLCKhp3YEmBuko71ivcMoIZcCLXgQVck6aNswX+AWwaek/L8S3yz9i8m3tHigRkcF6F2vI+qtdtyySHK+bGA=="
     },
     "@httptoolkit/websocket-stream": {
       "version": "6.0.0",
@@ -13714,9 +13483,9 @@
       "integrity": "sha512-gI5Sl30tmhXsqkNvopFydP7ASc4c2cLfGNQrVKN3X90ADFWFsPEsotm/8JHSUJQKTHbwowAHtcJPeyVhtKv0TQ=="
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg=="
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g=="
     },
     "@types/sizzle": {
       "version": "2.3.2",
@@ -13788,6 +13557,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13901,9 +13671,9 @@
       }
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -14396,7 +14166,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "peer": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -14466,9 +14235,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
     },
     "caniuse-lite": {
       "version": "1.0.30001307",
@@ -14585,12 +14354,11 @@
       }
     },
     "cli-table3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
-      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
+        "colors": "1.4.0",
         "string-width": "^4.2.0"
       }
     },
@@ -15220,23 +14988,24 @@
       "integrity": "sha1-f1x7cACbwrZmWRv+ZIVFeL7e6Fo="
     },
     "cypress": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.7.0.tgz",
-      "integrity": "sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.2.tgz",
+      "integrity": "sha512-gYiQYvJozMzDOriUV1rCt6CeRM/pRK4nhwGJj3nJQyX2BoUdTCVwp30xDMKc771HiNVhBtgj5o5/iBdVDVXQUg==",
       "requires": {
-        "@cypress/request": "^2.88.6",
+        "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.0",
+        "cli-table3": "~0.6.1",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -15259,12 +15028,11 @@
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
-        "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
@@ -15325,24 +15093,13 @@
       }
     },
     "cypress-dotenv": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cypress-dotenv/-/cypress-dotenv-1.2.3.tgz",
-      "integrity": "sha512-9TsM0iy21Js0muRqNEBvMaIJpx2jRR6HtFuSJXJFacxrGZnnFqzl+TiOOlquIcqGxIzPTFKOLztWMAP2qU21qw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-dotenv/-/cypress-dotenv-2.0.0.tgz",
+      "integrity": "sha512-MHCkWuTU51n/Q6LT2FgjNVZx/OmnrP3Jve7TUGZvSbjgGOpBOVZTbm3tomjvn+2S6HhloRXSAOmT5fY9pvWkpQ==",
       "requires": {
-        "camelcase": "^5.3.1",
-        "dotenv-parse-variables": "^0.2.3",
-        "lodash.clonedeep": "^2.0.0"
-      },
-      "dependencies": {
-        "lodash.clonedeep": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-2.4.1.tgz",
-          "integrity": "sha1-8pIDtAsS/uCkXTYxZIJZvrq8eGg=",
-          "requires": {
-            "lodash._baseclone": "~2.4.1",
-            "lodash._basecreatecallback": "~2.4.1"
-          }
-        }
+        "camelcase": "^6.2.0",
+        "dotenv-parse-variables": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
       }
     },
     "d": {
@@ -15502,16 +15259,17 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
     "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
     },
     "dotenv-parse-variables": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv-parse-variables/-/dotenv-parse-variables-0.2.3.tgz",
-      "integrity": "sha512-cuog/uu2sD6AGTExLldBqN4kUWNjGG86cSpYGYgZrzgSiy37HkB3OOpMv7cTiQ7SKCMu8WryUS9P6lqwrh0pLg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-parse-variables/-/dotenv-parse-variables-2.0.0.tgz",
+      "integrity": "sha512-/Tezlx6xpDqR6zKg1V4vLCeQtHWiELhWoBz5A/E0+A1lXN9iIkNbbfc4THSymS0LQUo8F1PMiIwVG8ai/HrnSA==",
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.3.1",
+        "is-string-and-not-blank": "^0.0.2"
       }
     },
     "duplexer2": {
@@ -16123,12 +15881,14 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -16458,20 +16218,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -16585,13 +16331,13 @@
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
     },
     "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
       "requires": {
         "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.14.1"
       }
     },
     "https-browserify": {
@@ -16867,6 +16613,19 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-string-and-not-blank": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/is-string-and-not-blank/-/is-string-and-not-blank-0.0.2.tgz",
+      "integrity": "sha512-FyPGAbNVyZpTeDCTXnzuwbu9/WpNXbCfbHXLpCRpN4GANhS00eEIP5Ef+k5HYSNIzIhdN9zRDoBj6unscECvtQ==",
+      "requires": {
+        "is-string-blank": "^1.0.1"
+      }
+    },
+    "is-string-blank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -16973,14 +16732,15 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "0.0.1",
@@ -17038,13 +16798,13 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -17160,153 +16920,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash._arraypool": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
-      "integrity": "sha1-6I7suS4ruEyQZWEv2VigcZzUf5Q="
-    },
-    "lodash._basebind": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
-      "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
-      "requires": {
-        "lodash._basecreate": "~2.4.1",
-        "lodash._setbinddata": "~2.4.1",
-        "lodash._slice": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
-    "lodash._baseclone": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
-      "integrity": "sha1-MPgj5X4X43NdODvWK2Czh1Q7QYY=",
-      "requires": {
-        "lodash._getarray": "~2.4.1",
-        "lodash._releasearray": "~2.4.1",
-        "lodash._slice": "~2.4.1",
-        "lodash.assign": "~2.4.1",
-        "lodash.foreach": "~2.4.1",
-        "lodash.forown": "~2.4.1",
-        "lodash.isarray": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
-    "lodash._basecreate": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-      "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
-      "requires": {
-        "lodash._isnative": "~2.4.1",
-        "lodash.isobject": "~2.4.1",
-        "lodash.noop": "~2.4.1"
-      }
-    },
-    "lodash._basecreatecallback": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
-      "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
-      "requires": {
-        "lodash._setbinddata": "~2.4.1",
-        "lodash.bind": "~2.4.1",
-        "lodash.identity": "~2.4.1",
-        "lodash.support": "~2.4.1"
-      }
-    },
-    "lodash._basecreatewrapper": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
-      "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
-      "requires": {
-        "lodash._basecreate": "~2.4.1",
-        "lodash._setbinddata": "~2.4.1",
-        "lodash._slice": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
-    "lodash._createwrapper": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-      "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
-      "requires": {
-        "lodash._basebind": "~2.4.1",
-        "lodash._basecreatewrapper": "~2.4.1",
-        "lodash._slice": "~2.4.1",
-        "lodash.isfunction": "~2.4.1"
-      }
-    },
-    "lodash._getarray": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
-      "integrity": "sha1-+vH3+BD6mFolHCGHQESBCUg55e4=",
-      "requires": {
-        "lodash._arraypool": "~2.4.1"
-      }
-    },
-    "lodash._isnative": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
-    },
-    "lodash._maxpoolsize": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz",
-      "integrity": "sha1-nUgvRjuOZq++WcLBTtsRcGAXIzQ="
-    },
-    "lodash._objecttypes": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
-    },
-    "lodash._releasearray": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
-      "integrity": "sha1-phOWMNdtFTawfdyAliiJsIL2pkE=",
-      "requires": {
-        "lodash._arraypool": "~2.4.1",
-        "lodash._maxpoolsize": "~2.4.1"
-      }
-    },
-    "lodash._setbinddata": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-      "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
-      "requires": {
-        "lodash._isnative": "~2.4.1",
-        "lodash.noop": "~2.4.1"
-      }
-    },
-    "lodash._shimkeys": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-      "requires": {
-        "lodash._objecttypes": "~2.4.1"
-      }
-    },
-    "lodash._slice": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
-      "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8="
-    },
-    "lodash.assign": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
-      "integrity": "sha1-hMOVlt1xGBqXsGUpE6fJZ15Jsao=",
-      "requires": {
-        "lodash._basecreatecallback": "~2.4.1",
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
-      }
-    },
-    "lodash.bind": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
-      "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
-      "requires": {
-        "lodash._createwrapper": "~2.4.1",
-        "lodash._slice": "~2.4.1"
-      }
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -17317,70 +16930,10 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.foreach": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
-      "integrity": "sha1-/j/Do0yGyUyrb5UiVgKCdB4BYwk=",
-      "requires": {
-        "lodash._basecreatecallback": "~2.4.1",
-        "lodash.forown": "~2.4.1"
-      }
-    },
-    "lodash.forown": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
-      "integrity": "sha1-eLQer+FAX6lmRZ6kGT/VAtCEUks=",
-      "requires": {
-        "lodash._basecreatecallback": "~2.4.1",
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
-      }
-    },
-    "lodash.identity": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
-      "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE="
-    },
-    "lodash.isarray": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
-      "integrity": "sha1-tSoybB9i9tfac6MdVAHfbvRPD6E=",
-      "requires": {
-        "lodash._isnative": "~2.4.1"
-      }
-    },
-    "lodash.isfunction": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
-      "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE="
-    },
-    "lodash.isobject": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-      "requires": {
-        "lodash._objecttypes": "~2.4.1"
-      }
-    },
-    "lodash.keys": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-      "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-      "requires": {
-        "lodash._isnative": "~2.4.1",
-        "lodash._shimkeys": "~2.4.1",
-        "lodash.isobject": "~2.4.1"
-      }
-    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
-    },
-    "lodash.noop": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
-      "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -17404,14 +16957,6 @@
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
       "peer": true
-    },
-    "lodash.support": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
-      "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
-      "requires": {
-        "lodash._isnative": "~2.4.1"
-      }
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -17549,16 +17094,16 @@
       }
     },
     "mime-db": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-      "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
-        "mime-db": "1.49.0"
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
@@ -18318,9 +17863,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -18331,11 +17876,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
-    },
-    "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -18617,7 +18157,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -18783,9 +18322,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -19395,6 +18934,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,17 +34,17 @@
   },
   "homepage": "https://github.com/DEFRA/sroc-acceptance-tests#readme",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.35.0",
-    "@faker-js/faker": "^6.0.0-alpha.7",
+    "@aws-sdk/client-s3": "^3.55.0",
+    "@faker-js/faker": "^6.0.0",
     "cucumber-html-reporter": "^5.5.0",
-    "cypress": "^8.3.1",
-    "cypress-cucumber-preprocessor": "^4.2.0",
-    "cypress-dotenv": "^1.2.2",
-    "dotenv": "^8.2.0",
+    "cypress": "^9.5.2",
+    "cypress-cucumber-preprocessor": "^4.3.1",
+    "cypress-dotenv": "^2.0.0",
+    "dotenv": "^16.0.0",
     "path": "^0.12.7"
   },
   "devDependencies": {
-    "standard": "^16.0.3"
+    "standard": "^16.0.4"
   },
   "cypress-cucumber-preprocessor": {
     "nonGlobalStepDefinitions": true,


### PR DESCRIPTION
We've been getting a nag message about the version of Cypress being used for a while now. So, this change goes through the `package.json` and updates all references to the current latest versions.