### PR TITLE
Fix email scenarios

### DIFF
--- a/cypress/integration/common/email.js
+++ b/cypress/integration/common/email.js
@@ -109,7 +109,7 @@ And('I have forgotten my password', () => {
 
 When('I follow the link to unlock my account', () => {
   cy.get('@user').then((user) => {
-    LastEmailPage.lastEmail([user.email, 'Your account has been locked'])
+    LastEmailPage.lastEmail([user.email, 'account has been locked'])
 
     cy.get('@lastEmail').then((lastEmail) => {
       const link = LastEmailPage.extractUnlockAccountLink(lastEmail.last_email.body)

--- a/cypress/integration/common/email.js
+++ b/cypress/integration/common/email.js
@@ -109,7 +109,7 @@ And('I have forgotten my password', () => {
 
 When('I follow the link to unlock my account', () => {
   cy.get('@user').then((user) => {
-    LastEmailPage.lastEmail([user.email, 'account has been locked'])
+    LastEmailPage.lastEmail([`Hello ${user.firstName} ${user.lastName}`, 'account has been locked'])
 
     cy.get('@lastEmail').then((lastEmail) => {
       const link = LastEmailPage.extractUnlockAccountLink(lastEmail.last_email.body)

--- a/cypress/pages/accept_invite_page.js
+++ b/cypress/pages/accept_invite_page.js
@@ -4,7 +4,7 @@ class AcceptInvitePage {
   }
 
   static mainHeading () {
-    return cy.get('h1')
+    return cy.get('h2')
   }
 
   static password () {


### PR DESCRIPTION
In [PR #57](https://github.com/DEFRA/sroc-acceptance-tests/pull/57) we added our first email scenarios. Since then we've [switched the TCM to GOV.UK Notify](https://github.com/DEFRA/sroc-tcm-admin/pull/546) and [updated all the project dependencies](https://github.com/DEFRA/sroc-acceptance-tests/pull/61).

We believe for these reasons a couple of the email scenarios have stopped working. This change fixes them.