### PR TITLE
Remove WIP message from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SROC acceptance tests
 
-> Work in progress! Intended to replace [sroc-tcm-acceptance-tests]()https://github.com/DEFRA/sroc-tcm-acceptance-tests. It includes some initial feature tests which run successfully across all non-production environments.
-
 The Tactical Charging Module (TCM) is a web application designed to enable billing adminstrators to apply new categories to permit charges to enable correct amounts to be processed.
 
 This service is an internally facing service only, used by billing administration staff.


### PR DESCRIPTION
Should really have removed this when we did [Add legacy CFD feature from Java project](https://github.com/DEFRA/sroc-acceptance-tests/pull/41), [Add legacy PAS feature from Java project](https://github.com/DEFRA/sroc-acceptance-tests/pull/47) and [Add legacy WML feature from Java project](https://github.com/DEFRA/sroc-acceptance-tests/pull/48). With those legacy tests added we were able to archive off the old Java based project the message referred to.