### PR TITLE
Add feature for enabled and disabled users

### DIFF
--- a/cypress/integration/authorisation/disabled_enabled.feature
+++ b/cypress/integration/authorisation/disabled_enabled.feature
@@ -8,3 +8,11 @@ Feature: Disabled and enabled users
     Given my account has been disabled
     When I sign in as the 'readonly' user
     Then the TCM refuses me access
+
+  Scenario: Enabling a disabled user
+    Given my account has been disabled
+    When I sign in as the 'readonly' user
+    Then the TCM refuses me access
+    When my account has been enabled
+    And I sign in as the 'readonly' user
+    Then the TCM allows me access

--- a/cypress/integration/authorisation/disabled_enabled.feature
+++ b/cypress/integration/authorisation/disabled_enabled.feature
@@ -1,0 +1,10 @@
+Feature: Disabled and enabled users
+
+  As the business responsible for the system
+  I need to ensure
+  That only enabled users can access the TCM
+
+  Scenario: Disabling a user
+    Given my account has been disabled
+    When I sign in as the 'readonly' user
+    Then the TCM refuses me access

--- a/cypress/integration/authorisation/disabled_enabled/disabled_enabled_steps.js
+++ b/cypress/integration/authorisation/disabled_enabled/disabled_enabled_steps.js
@@ -1,0 +1,44 @@
+import { Before, Given, Then } from 'cypress-cucumber-preprocessor/steps'
+import EditUserPage from '../../../pages/edit_user_page'
+import SignInPage from '../../../pages/sign_in_page'
+import TransactionsPage from '../../../pages/transactions_page'
+import UsersPage from '../../../pages/users_page'
+
+Before(() => {
+  cy.intercept('GET', '**/users?search=*').as('getSearch')
+})
+
+Given('my account has been {word}', (status) => {
+  cy.signIn(Cypress.config().users.admin.email)
+
+  TransactionsPage.adminMenu.getOption('User Management', '').click()
+  UsersPage.searchNameInput().type('Readonly')
+  UsersPage.submitButton().click()
+
+  cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
+
+  UsersPage.searchResultsTable().each((_element, index) => {
+    cy.get(`.table-responsive > tbody > tr:nth-child(${index + 1}) td`).eq(2).invoke('text').then((email) => {
+      if (email === 'readonly@sroc.gov.uk') {
+        cy.get(`.table-responsive > tbody > tr:nth-child(${index + 1})`).invoke('attr', 'id').then((id) => {
+          UsersPage.searchResultEditButton(id).click()
+          if (status === 'enabled') {
+            EditUserPage.enabledCheckbox().check()
+          } else {
+            EditUserPage.enabledCheckbox().uncheck()
+          }
+        })
+      }
+    })
+  })
+
+  cy.signOut()
+})
+
+Then('the TCM refuses me access', () => {
+  SignInPage.confirm()
+
+  cy.alertShouldContain(
+    'Your account is not enabled.  Contact your administrator.'
+  )
+})

--- a/cypress/integration/authorisation/disabled_enabled/disabled_enabled_steps.js
+++ b/cypress/integration/authorisation/disabled_enabled/disabled_enabled_steps.js
@@ -27,6 +27,7 @@ Given('my account has been {word}', (status) => {
           } else {
             EditUserPage.enabledCheckbox().uncheck()
           }
+          EditUserPage.submitButton().click()
         })
       }
     })
@@ -41,4 +42,10 @@ Then('the TCM refuses me access', () => {
   cy.alertShouldContain(
     'Your account is not enabled.  Contact your administrator.'
   )
+})
+
+Then('the TCM allows me access', () => {
+  TransactionsPage.confirm()
+
+  TransactionsPage.userMenu.menuLink().should('contain', 'Readonly User')
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-297

We have our existing `cypress/integration/authorisation` feature which covers the different roles and regime access the TCM grants. But we don't have anything that checks the access of disabled accounts.

This change adds a feature to cover this.