### PR TITLE
Add clean DB command

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -133,3 +133,22 @@ Cypress.Commands.add('addUser', (user) => {
 Cypress.Commands.add('alertShouldContain', (text) => {
   cy.get('.col > .alert').should('contain.text', text)
 })
+
+/**
+ * Use when you want to clean the database of transaction based data
+ *
+ * Some of the features depend on the data being in a known state. That way expectations about, for example, finding
+ * certain transactions to approve will succeed.
+ *
+ * The `/clean` command in the TCM doesn't completely reset the DB. Lookup tables such as permit categories, and records
+ * such as user accounts are left untouched. But anything to do with transactions, transaction files, and import and
+ * export history is all deleted and the identifiers restarted.
+ */
+Cypress.Commands.add('cleanDb', () => {
+  cy.log('Cleaning the database')
+  cy.request({
+    log: false,
+    method: 'GET',
+    url: '/clean'
+  }).its('status', { log: false }).should('equal', 200)
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-281

We recently updated the TCM and [Added a test-only reset DB endpoint](https://github.com/DEFRA/sroc-tcm-admin/pull/544). The purpose was so we could set the database to a known state prior to running certain features in this project.

The legacy features are the key ones; they depend on the database having known records in known states prior to running. This is something we currently do manually but adding a DB clean command is the first step to then automating the legacy tests fully.