### PR TITLE
Automate db clean and import of regime test files

### DIFF
--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -97,13 +97,13 @@ And('I select {word} for financial year in the search bar', (option) => {
   })
 })
 
-And('I select {word} for items per page in the paging info bar', (option) => {
-  cy.get('select#per_page').select(option)
+And('I select {int} for items per page in the paging info bar', (option) => {
+  cy.get('select#per_page').select(option.toString())
 
   cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
 
   cy.get('select#per_page').find(':selected').invoke('text').then((val) => {
-    expect(val).to.equal(option)
+    expect(val).to.equal(option.toString())
   })
 })
 

--- a/cypress/integration/legacy/pas/pas_steps.js
+++ b/cypress/integration/legacy/pas/pas_steps.js
@@ -103,13 +103,13 @@ And('I select {word} for financial year in the search bar', (option) => {
   })
 })
 
-And('I select {word} for items per page in the paging info bar', (option) => {
-  cy.get('select#per_page').select(option)
+And('I select {int} for items per page in the paging info bar', (option) => {
+  cy.get('select#per_page').select(option.toString())
 
   cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
 
   cy.get('select#per_page').find(':selected').invoke('text').then((val) => {
-    expect(val).to.equal(option)
+    expect(val).to.equal(option.toString())
   })
 })
 

--- a/cypress/integration/legacy/wml/wml_steps.js
+++ b/cypress/integration/legacy/wml/wml_steps.js
@@ -103,13 +103,13 @@ And('I select {word} for financial year in the search bar', (option) => {
   })
 })
 
-And('I select {word} for items per page in the paging info bar', (option) => {
-  cy.get('select#per_page').select(option)
+And('I select {int} for items per page in the paging info bar', (option) => {
+  cy.get('select#per_page').select(option.toString())
 
   cy.wait('@getSearch').its('response.statusCode').should('eq', 200)
 
   cy.get('select#per_page').find(':selected').invoke('text').then((val) => {
-    expect(val).to.equal(option)
+    expect(val).to.equal(option.toString())
   })
 })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-280

This project now has the ability to request the TCM clean its DB and import a specified transaction import file. What we haven't done is integrate these features into our legacy tests which depend on them to get the database into a known state.

This change updates the legacy features to fully automate getting the database ready for testing. Once done it should mean we can now re-run the legacy tests with no manual intervention whatsoever.