### PR TITLE
Delete legacy Download data checks

### DIFF
--- a/cypress/integration/data_export/general.feature
+++ b/cypress/integration/data_export/general.feature
@@ -5,6 +5,6 @@ Feature: Data Export
 
   Scenario: Download transaction data
     When I select the 'Installations' regime
-     And I proceed to view file download details
+    And I proceed to view file download details
     Then I can view the Data Protection Notice
-     And I can download transaction data
+    And I can download transaction data

--- a/cypress/integration/legacy/cfd.feature
+++ b/cypress/integration/legacy/cfd.feature
@@ -69,7 +69,3 @@ Feature: CFD (Water Quality) Legacy
     Then I click the export button and check the export modal displays
     Then I generate the pre-sroc transaction file
     Then I see confirmation the transaction file is queued for export
-    # The section that checked downloading transaction data was commented out in the legacy test.
-    And I select 'Download Transaction Data' from the Transactions menu
-    And the main heading is 'Download Transaction Data'
-    And I confirm the data protection notice is displayed

--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -362,9 +362,3 @@ Then('I generate the pre-sroc transaction file', () => {
 
   cy.wait('@getRetrospectivesSearch').its('response.statusCode').should('eq', 200)
 })
-
-And('I confirm the data protection notice is displayed', () => {
-  cy.get('.card-header')
-    .should('contain', 'Data Protection Notice')
-    .should('be.visible')
-})

--- a/cypress/integration/legacy/pas.feature
+++ b/cypress/integration/legacy/pas.feature
@@ -66,7 +66,3 @@ Feature: PAS (Installations) Legacy
     Then I click the export button and check the export modal displays
     Then I generate the pre-sroc transaction file
     Then I see confirmation the transaction file is queued for export
-    # The section that checked downloading transaction data was commented out in the legacy test.
-    And I select 'Download Transaction Data' from the Transactions menu
-    And the main heading is 'Download Transaction Data'
-    And I confirm the data protection notice is displayed

--- a/cypress/integration/legacy/pas/pas_steps.js
+++ b/cypress/integration/legacy/pas/pas_steps.js
@@ -335,9 +335,3 @@ Then('I generate the pre-sroc transaction file', () => {
 
   cy.wait('@getRetrospectivesSearch').its('response.statusCode').should('eq', 200)
 })
-
-And('I confirm the data protection notice is displayed', () => {
-  cy.get('.card-header')
-    .should('contain', 'Data Protection Notice')
-    .should('be.visible')
-})

--- a/cypress/integration/legacy/wml.feature
+++ b/cypress/integration/legacy/wml.feature
@@ -56,6 +56,3 @@ Feature: WML (Installations) Legacy
     And I select 'Transaction History' from the Transactions menu
     And the main heading is 'Transaction History'
     Then I click the export button and check the export modal displays
-    And I select 'Download Transaction Data' from the Transactions menu
-    And the main heading is 'Download Transaction Data'
-    And I confirm the data protection notice is displayed

--- a/cypress/integration/legacy/wml/wml_steps.js
+++ b/cypress/integration/legacy/wml/wml_steps.js
@@ -276,9 +276,3 @@ And('I set region to {word}', (option) => {
 
   cy.wait('@getTransactionFileHistory').its('response.statusCode').should('eq', 200)
 })
-
-And('I confirm the data protection notice is displayed', () => {
-  cy.get('.card-header')
-    .should('contain', 'Data Protection Notice')
-    .should('be.visible')
-})


### PR DESCRIPTION
Overlooked that we now have a feature dedicated to checking the **Download Transaction Data** page.

Because of this, there is no need to duplicate the steps in the legacy tests. This will help to simplify them and move them into something more meaningful and manageable.
