### PR TITLE
Move exclude transaction to own feature

### DIFF
--- a/cypress/integration/exclusions/general.feature
+++ b/cypress/integration/exclusions/general.feature
@@ -1,0 +1,13 @@
+Feature: Exclusions
+
+  Background:
+    Given I am starting with known pas data
+    And I sign in as the 'installations' user
+
+  Scenario: Exclude and reinstate transaction
+    When I exclude the first transaction
+    Then I see confirmation the transaction has been updated
+    And I see the transaction struck through in transactions to be billed
+    Then if I reinstate the transaction
+    Then I see confirmation the transaction has been updated
+    And I no longer see the transaction struck through in transactions to be billed

--- a/cypress/integration/exclusions/general/general_steps.js
+++ b/cypress/integration/exclusions/general/general_steps.js
@@ -1,0 +1,36 @@
+import { And, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+import TransactionDetailPage from '../../../pages/transaction_detail_page'
+import TransactionsPage from '../../../pages/transactions_page'
+
+When('I exclude the first transaction', () => {
+  TransactionsPage.table.showDetailsButton(0).click()
+
+  TransactionDetailPage.confirm()
+  TransactionDetailPage.excludeFromBillingButton().click()
+  TransactionDetailPage.excludeTransactionButton().click()
+})
+
+Then('I see confirmation the transaction has been updated', () => {
+  cy.alertShouldContain(
+    'Transaction was successfully updated.'
+  )
+})
+
+And('I see the transaction struck through in transactions to be billed', () => {
+  TransactionDetailPage.transactionsMenu.getOption('Transactions to be billed', 'pas').click()
+
+  TransactionsPage.table.firstRow().should('have.class', 'excluded')
+})
+
+Then('if I reinstate the transaction', () => {
+  TransactionsPage.table.showDetailsButton(0).click()
+
+  TransactionDetailPage.reinstateForBillingButton().click()
+})
+
+And('I no longer see the transaction struck through in transactions to be billed', () => {
+  TransactionDetailPage.transactionsMenu.getOption('Transactions to be billed', 'pas').click()
+
+  TransactionsPage.table.firstRow().should('not.have.class', 'excluded')
+})

--- a/cypress/integration/legacy/cfd.feature
+++ b/cypress/integration/legacy/cfd.feature
@@ -31,8 +31,6 @@ Feature: CFD (Water Quality) Legacy
     And the main heading is 'Transaction change history'
     And the first event is Transaction imported from file
     Then I go back using the link
-    And exclude the transaction
-    And reinstate the transaction
     Then I go back using the link
     Then I go back using the link
     Then I go back using the link

--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -223,19 +223,6 @@ Then('I set the temporary cessation flag for the first transaction', () => {
   cy.get('.table-responsive > tbody > tr:first-child select.temporary-cessation-select').select('Y').should('have.value', 'true')
 })
 
-And('exclude the transaction', () => {
-  cy.get('button.exclude-button').click()
-  cy.get('input[type="submit"][data-disable-with="Exclude Transaction"]').click()
-  cy.get('span.badge-danger').should('contain.text', 'Marked for Exclusion')
-})
-
-And('reinstate the transaction', () => {
-  cy.get('input[type="submit"][data-disable-with="Reinstate for Billing"]').click()
-  cy.get('button.exclude-button').should('be.visible')
-
-  cy.wait('@getTransaction').its('response.statusCode').should('eq', 200)
-})
-
 And('approve the transactions for billing', () => {
   cy.get('button.approve-all-btn').click()
 

--- a/cypress/integration/legacy/pas.feature
+++ b/cypress/integration/legacy/pas.feature
@@ -29,8 +29,6 @@ Feature: PAS (Installations) Legacy
     And the main heading is 'Transaction change history'
     And the first event is Transaction imported from file
     Then I go back using the link
-    And exclude the transaction
-    And reinstate the transaction
     Then I go back using the link
     Then I go back using the link
     Then I go back using the link

--- a/cypress/integration/legacy/pas/pas_steps.js
+++ b/cypress/integration/legacy/pas/pas_steps.js
@@ -137,19 +137,6 @@ Then('I go back using the link', () => {
   cy.get('.back-link').click()
 })
 
-And('exclude the transaction', () => {
-  cy.get('button.exclude-button').click()
-  cy.get('input[type="submit"][data-disable-with="Exclude Transaction"]').click()
-  cy.get('span.badge-danger').should('contain.text', 'Marked for Exclusion')
-})
-
-And('reinstate the transaction', () => {
-  cy.get('input[type="submit"][data-disable-with="Reinstate for Billing"]').click()
-  cy.get('button.exclude-button').should('be.visible')
-
-  cy.wait('@getTransaction').its('response.statusCode').should('eq', 200)
-})
-
 Then('I click the export button and check the export modal displays', () => {
   cy.get('button.table-export-btn').click()
   // NOTE: Whilst handy to confirm the dialog has appeared this is actually here to force the tests to wait for the

--- a/cypress/integration/legacy/wml.feature
+++ b/cypress/integration/legacy/wml.feature
@@ -30,8 +30,6 @@ Feature: WML (Installations) Legacy
     And the main heading is 'Transaction change history'
     And the first event is Transaction imported from file
     Then I go back using the link
-    And exclude the transaction
-    And reinstate the transaction
     Then I go back using the link
     Then I go back using the link
     Then I go back using the link

--- a/cypress/integration/legacy/wml/wml_steps.js
+++ b/cypress/integration/legacy/wml/wml_steps.js
@@ -137,19 +137,6 @@ Then('I go back using the link', () => {
   cy.get('.back-link').click()
 })
 
-And('exclude the transaction', () => {
-  cy.get('button.exclude-button').click()
-  cy.get('input[type="submit"][data-disable-with="Exclude Transaction"]').click()
-  cy.get('span.badge-danger').should('contain.text', 'Marked for Exclusion')
-})
-
-And('reinstate the transaction', () => {
-  cy.get('input[type="submit"][data-disable-with="Reinstate for Billing"]').click()
-  cy.get('button.exclude-button').should('be.visible')
-
-  cy.wait('@getTransaction').its('response.statusCode').should('eq', 200)
-})
-
 Then('I click the export button and check the export modal displays', () => {
   cy.get('button.table-export-btn').click()
   // NOTE: Whilst handy to confirm the dialog has appeared this is actually here to force the tests to wait for the

--- a/cypress/pages/transaction_detail_page.js
+++ b/cypress/pages/transaction_detail_page.js
@@ -1,0 +1,28 @@
+import BaseAppPage from './base_app_page'
+
+class TransactionDetailPage extends BaseAppPage {
+  static confirm () {
+    cy.get('h1').should('contain', 'Transaction detail')
+    cy.url().should('match', /regimes\/[a-z]{3}\/transactions\/\d*/)
+  }
+
+  // Elements
+
+  static excludeFromBillingButton () {
+    return cy.get('button.exclude-button')
+  }
+
+  static excludeTransactionButton () {
+    return cy.get('input[type="submit"][data-disable-with="Exclude Transaction"]')
+  }
+
+  static reinstateForBillingButton () {
+    return cy.get('input[type="submit"][data-disable-with="Reinstate for Billing"]')
+  }
+
+  static viewChangeHistoryButton () {
+    return cy.get('a.btn-outline-info')
+  }
+}
+
+export default TransactionDetailPage


### PR DESCRIPTION
All 3 legacy tests include steps where we exclude then immediately reinstate a transaction. The steps as they are don't really do much but do make the legacy tests more complex than they need to be.

This change moves them to their own feature and expands the steps to include a bit more checking of what we expect to happen when a transaction is excluded.