### PR TITLE
Add our first table object

### DIFF
--- a/cypress/integration/bugs/general/general_steps.js
+++ b/cypress/integration/bugs/general/general_steps.js
@@ -28,7 +28,7 @@ And('I search for permit reference {word}', (reference) => {
 })
 
 And('I see results', () => {
-  TransactionsPage.resultsTable().find('tr').should('have.length.greaterThan', 1)
+  TransactionsPage.table.rows().should('have.length.greaterThan', 1)
 })
 
 Then('I select {string} from the transactions menu', (optionText) => {
@@ -36,7 +36,7 @@ Then('I select {string} from the transactions menu', (optionText) => {
 })
 
 And('I do not see results', () => {
-  TransactionsPage.resultsTable().find('tr').should('have.length', 1)
+  TransactionsPage.table.rows().should('have.length', 1)
 })
 
 But('if I clear the search field and search again', () => {

--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -76,7 +76,7 @@ Then('the first record has file reference {string}', (fileReference) => {
 })
 
 And('I log the number of transactions displayed', () => {
-  TransactionsPage.resultsTable().find('tbody').find('tr').then((rows) => {
+  TransactionsPage.table.rows().then((rows) => {
     cy.log(`Number of transactions listed is ${rows.length}`)
   })
 })

--- a/cypress/integration/legacy/pas/pas_steps.js
+++ b/cypress/integration/legacy/pas/pas_steps.js
@@ -82,7 +82,7 @@ Then('the first record has file reference {string}', (fileReference) => {
 })
 
 And('I log the number of transactions displayed', () => {
-  TransactionsPage.resultsTable().find('tbody').find('tr').then((rows) => {
+  TransactionsPage.table.rows().then((rows) => {
     cy.log(`Number of transactions listed is ${rows.length}`)
   })
 })

--- a/cypress/integration/legacy/wml/wml_steps.js
+++ b/cypress/integration/legacy/wml/wml_steps.js
@@ -82,7 +82,7 @@ Then('the first record has file reference {string}', (fileReference) => {
 })
 
 And('I log the number of transactions displayed', () => {
-  TransactionsPage.resultsTable().find('tbody').find('tr').then((rows) => {
+  TransactionsPage.table.rows().then((rows) => {
     cy.log(`Number of transactions listed is ${rows.length}`)
   })
 })

--- a/cypress/integration/transactions/general.feature
+++ b/cypress/integration/transactions/general.feature
@@ -1,9 +1,9 @@
 Feature: Transactions
 
   Background:
-    Given I sign in as the 'admin' user
+    Given I am starting with known wml data
+    And I sign in as the 'waste' user
 
   Scenario: Search for customer
-    When I select the 'Water Quality' regime
-    And I search for the customer 'A61000001C'
-    Then I see only results for customer 'A61000001C'
+    When I search for the customer 'Y02000001J'
+    Then I see only results for customer 'Y02000001J'

--- a/cypress/integration/transactions/general/general_steps.js
+++ b/cypress/integration/transactions/general/general_steps.js
@@ -1,4 +1,4 @@
-import { Then, And, Before } from 'cypress-cucumber-preprocessor/steps'
+import { Then, When, Before } from 'cypress-cucumber-preprocessor/steps'
 import TransactionsPage from '../../../pages/transactions_page'
 
 Before(() => {
@@ -20,7 +20,7 @@ Before(() => {
   cy.intercept('GET', '**/regimes/*/transactions?search=*').as('getSearch')
 })
 
-And('I search for the customer {string}', (customer) => {
+When('I search for the customer {string}', (customer) => {
   TransactionsPage.searchInput().type(customer)
   TransactionsPage.submitButton().click()
 
@@ -28,7 +28,7 @@ And('I search for the customer {string}', (customer) => {
 })
 
 Then('I see only results for customer {string}', (customer) => {
-  TransactionsPage.customerColumn().each(($el) => {
+  TransactionsPage.table.cells('Customer', 'wml').each(($el) => {
     expect($el.text()).to.have.string(customer)
   })
 })

--- a/cypress/integration/transactions/sorting/sorting_steps.js
+++ b/cypress/integration/transactions/sorting/sorting_steps.js
@@ -1,7 +1,5 @@
 import { Then, When, Before } from 'cypress-cucumber-preprocessor/steps'
 
-import { columnPickerHelper } from '../../../support/helpers'
-
 import SignInPage from '../../../pages/sign_in_page'
 import TransactionsPage from '../../../pages/transactions_page'
 
@@ -23,7 +21,7 @@ Then('I am on the Transactions to be Billed page', () => {
 
 When('I sort by {string} in {word} order', (column, sortOrder) => {
   cy.get('@regime').then((regime) => {
-    const dataColumn = columnPickerHelper(column, regime.slug)
+    const dataColumn = TransactionsPage.table.columnPicker(column, regime.slug)
 
     const sortOrders = {
       ascending: { class: 'sorted-asc', caret: 'oi-caret-top' },
@@ -62,8 +60,6 @@ When('I sort by {string} in {word} order', (column, sortOrder) => {
 
 Then('I see {string} as the first {string}', (value, column) => {
   cy.get('@regime').then((regime) => {
-    const dataColumn = columnPickerHelper(column, regime.slug)
-
-    TransactionsPage.resultsTable().find(`td:nth-child(${dataColumn.index})`).should('contain.text', value)
+    TransactionsPage.table.cell(0, column, regime.slug).should('contain.text', value)
   })
 })

--- a/cypress/pages/tables/base_table.js
+++ b/cypress/pages/tables/base_table.js
@@ -1,0 +1,15 @@
+class BaseTable {
+  static cell (rowNumber, columnName, regimeSlug) {
+    throw new Error("Extending class must implement 'cell()'")
+  }
+
+  static firstRow () {
+    return cy.get('.table-responsive > tbody > tr:first-child')
+  }
+
+  static rows () {
+    return cy.get('.table-responsive > tbody > tr')
+  }
+}
+
+export default BaseTable

--- a/cypress/pages/tables/transactions_to_be_billed_table.js
+++ b/cypress/pages/tables/transactions_to_be_billed_table.js
@@ -27,6 +27,11 @@ class TransactionsToBeBilledTable extends BaseTable {
 
   // support
 
+  /**
+   * Use to get all column details for a particular regime
+   *
+   * We need to know the regime because the transactions to be billed table is different for each one.
+   */
   static columns (regimeSlug) {
     const sharedColumns = {
       Customer: { name: 'customer_reference', index: 4 },
@@ -62,6 +67,17 @@ class TransactionsToBeBilledTable extends BaseTable {
     }
   }
 
+  /**
+   * Use to get a specific column's details
+   *
+   * Given a column name (as seen in the UI) and regime it will return its data-column name and TD nth-child position.
+   * We can then use this to either grab a value or check for the existance of one.
+   *
+   * We need to know the regime because the transactions to be billed table is different for each one.
+   *
+   * If the a matching column is not found it will throw an error. This is intended to help highlight errors caused by
+   * typos, for example, using wrong case quickly.
+   */
   static columnPicker (columnName, regimeSlug) {
     const regimeColumns = this.columns(regimeSlug)
 

--- a/cypress/pages/tables/transactions_to_be_billed_table.js
+++ b/cypress/pages/tables/transactions_to_be_billed_table.js
@@ -1,0 +1,76 @@
+import BaseTable from './base_table'
+
+class TransactionsToBeBilledTable extends BaseTable {
+  static categorySelect (rowNumber) {
+    return cy.get(`.table-responsive > tbody > tr:nth-child(${rowNumber + 1}) input.tcm-select-input`)
+  }
+
+  static cell (rowNumber, columnName, regimeSlug) {
+    const column = this.columnPicker(columnName, regimeSlug)
+
+    return cy.get(`.table-responsive tr:nth-child(${rowNumber + 1}) td:nth-child(${column.index})`)
+  }
+
+  static cells (columnName, regimeSlug) {
+    const column = this.columnPicker(columnName, regimeSlug)
+
+    return cy.get(`.table-responsive tr td:nth-child(${column.index})`)
+  }
+
+  static showDetailsButton (rowNumber) {
+    return cy.get(`.table-responsive tr:nth-child(${rowNumber + 1}) button.show-details-button`)
+  }
+
+  static temporaryCessationSelect (rowNumber) {
+    return cy.get(`.table-responsive tr:nth-child(${rowNumber + 1}) select.temporary-cessation-select`)
+  }
+
+  // support
+
+  static columns (regimeSlug) {
+    const sharedColumns = {
+      Customer: { name: 'customer_reference', index: 4 },
+      'File Date': { name: 'file_date', index: 3 },
+      'File Reference': { name: 'file_reference', index: 2 }
+    }
+
+    const regimeColumns = {
+      pas: {
+        Band: { name: 'compliance_band', index: 9 },
+        Category: { name: 'sroc_category', index: 7 },
+        'Original Permit': { name: 'original_permit_reference', index: 6 },
+        Period: { name: 'period', index: 11 },
+        Permit: { name: 'permit_reference', index: 5 }
+      },
+      cfd: {
+        Category: { name: 'sroc_category', index: 8 },
+        Consent: { name: 'consent_reference', index: 5 },
+        Period: { name: 'period', index: 12 },
+        '%': { name: 'variation', index: 10 }
+      },
+      wml: {
+        Band: { name: 'compliance_band', index: 8 },
+        Category: { name: 'sroc_category', index: 6 },
+        Period: { name: 'period', index: 10 },
+        Permit: { name: 'permit_reference', index: 5 }
+      }
+    }
+
+    return {
+      ...sharedColumns,
+      ...regimeColumns[regimeSlug]
+    }
+  }
+
+  static columnPicker (columnName, regimeSlug) {
+    const regimeColumns = this.columns(regimeSlug)
+
+    if (columnName in regimeColumns) {
+      return regimeColumns[columnName]
+    }
+
+    throw new Error(`Column '${columnName}' is unknown for ${regimeSlug}. Check your spelling and case!`)
+  }
+}
+
+export default TransactionsToBeBilledTable

--- a/cypress/pages/transactions_page.js
+++ b/cypress/pages/transactions_page.js
@@ -1,6 +1,11 @@
 import BaseAppPage from './base_app_page'
+import TransactionsToBeBilledTable from './tables/transactions_to_be_billed_table'
 
 class TransactionsPage extends BaseAppPage {
+  static get table () {
+    return TransactionsToBeBilledTable
+  }
+
   static confirm () {
     cy.get('h1').should('contain', 'Transactions to be billed')
     // As transactions is the root path when authenticated we can't guarantee we'll have a url to assert against.
@@ -16,14 +21,6 @@ class TransactionsPage extends BaseAppPage {
 
   static searchInput () {
     return cy.get('#search')
-  }
-
-  static resultsTable () {
-    return cy.get('.table')
-  }
-
-  static customerColumn () {
-    return cy.get('.table > tbody > tr > td:nth-child(4)')
   }
 }
 

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -7,60 +7,6 @@ import { faker } from '@faker-js/faker'
 // it as a helper helps reduce the complexity of the steps and makes the project a little more maintainable.
 
 /**
- * Use to get column details for a particular regime's transactions to be billed results table
- *
- * Written primarily to support our `cypress/integration/transactions/sorting.feature` given a column name (as seen in
- * the UI) and regime it will return its data-column name and TD nth-child position. We can then use this to grab the
- * value of a particular field.
- *
- * We need to know the regime because the results table is different for each one.
- *
- * If the a matching column is not found it will throw an error. This is intended to help highlight errors caused by
- * typos of using the wrong case quickly.
- */
-export function columnPickerHelper (column, regime) {
-  const sharedColumns = {
-    Customer: { name: 'customer_reference', index: 4 },
-    'File Date': { name: 'file_date', index: 3 },
-    'File Reference': { name: 'file_reference', index: 2 }
-  }
-
-  const regimeColumns = {
-    pas: {
-      Band: { name: 'compliance_band', index: 9 },
-      Category: { name: 'sroc_category', index: 7 },
-      'Original Permit': { name: 'original_permit_reference', index: 6 },
-      Period: { name: 'period', index: 11 },
-      Permit: { name: 'permit_reference', index: 5 }
-    },
-    cfd: {
-      Category: { name: 'sroc_category', index: 8 },
-      Consent: { name: 'consent_reference', index: 5 },
-      Period: { name: 'period', index: 12 },
-      '%': { name: 'variation', index: 10 }
-    },
-    wml: {
-      Band: { name: 'compliance_band', index: 8 },
-      Category: { name: 'sroc_category', index: 6 },
-      Period: { name: 'period', index: 10 },
-      Permit: { name: 'permit_reference', index: 5 }
-    }
-  }
-
-  const columns = {
-    ...sharedColumns,
-    ...regimeColumns[regime]
-  }
-  console.log(columns)
-
-  if (column in columns) {
-    return columns[column]
-  }
-
-  throw new Error(`Column '${column}' is unknown. Check your spelling and case!`)
-}
-
-/**
  * Use to determine which fixture file (test transaction import file) to use based on a regime slug
  *
  * We could have had steps in features just state the file name. But we felt it would read better in the scenario if
@@ -117,4 +63,4 @@ export function generateStringHelper (length = 8) {
   return faker.random.alpha({ count: length })
 }
 
-export default { columnPickerHelper, fixturePickerHelper, generateUserHelper, generateStringHelper }
+export default { fixturePickerHelper, generateUserHelper, generateStringHelper }


### PR DESCRIPTION
A large bulk of our steps involve interacting with tables in the UI. The tables show the results of searches and are our primary source of extracting data we then need in subsequent steps. Prior to this change, all this interaction was happening in the steps. How we referred to a table, its rows and columns wasn't always consistent and involved a lot of duplication.

We can though treat these tables in the same way we treat our menus and pages; as reusable objects in our steps. So, this change adds our first table object (which just happens to be the primary one) `TransactionsToBeBilledTable`. We've created a `BaseTable` following the pattern set down for page objects then extended our transactions to be billed table from it.

We were always a bit unsure of `columnPickerHelper()` because though strongly tied to the transactions table we don't make that explicit. Now that we have a table object we can move that code to where it arguably makes more sense.

We expect to add more table objects in the future.