### PR TITLE
Move legacy transaction history check to feature

### DIFF
--- a/cypress/integration/legacy/cfd.feature
+++ b/cypress/integration/legacy/cfd.feature
@@ -22,7 +22,6 @@ Feature: CFD (Water Quality) Legacy
     And I select 50 for items per page in the paging info bar
     And I see the 'Ver' column is displayed
     And I see the 'Dis' column is displayed
-    Then I set the temporary cessation flag for the first transaction
     Then I open the transaction detail page for the first transaction
     And the main heading is 'Transaction detail'
     And the sub heading 'Suggested category' is visible

--- a/cypress/integration/legacy/cfd.feature
+++ b/cypress/integration/legacy/cfd.feature
@@ -26,10 +26,6 @@ Feature: CFD (Water Quality) Legacy
     And the main heading is 'Transaction detail'
     And the sub heading 'Suggested category' is visible
     And the sub heading 'Related unbilled transactions' is visible
-    Then I open the transaction history page
-    And the main heading is 'Transaction change history'
-    And the first event is Transaction imported from file
-    Then I go back using the link
     Then I go back using the link
     Then I go back using the link
     Then I go back using the link

--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -219,10 +219,6 @@ Then('I click the export button and check the export modal displays', () => {
     .click()
 })
 
-Then('I set the temporary cessation flag for the first transaction', () => {
-  cy.get('.table-responsive > tbody > tr:first-child select.temporary-cessation-select').select('Y').should('have.value', 'true')
-})
-
 And('approve the transactions for billing', () => {
   cy.get('button.approve-all-btn').click()
 

--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -182,16 +182,6 @@ And('the sub heading {string} is visible', (heading) => {
     .should('be.visible')
 })
 
-Then('I open the transaction history page', () => {
-  cy.get('a.btn-outline-info').click()
-
-  cy.wait('@getTransactionHistory').its('response.statusCode').should('eq', 200)
-})
-
-And('the first event is Transaction imported from file', () => {
-  cy.get('tbody > tr:first-child > td:first-child').should('contain.text', 'Transaction imported from file')
-})
-
 Then('I go back using the link', () => {
   cy.get('.back-link').click()
 })

--- a/cypress/integration/legacy/pas.feature
+++ b/cypress/integration/legacy/pas.feature
@@ -24,10 +24,6 @@ Feature: PAS (Installations) Legacy
     And the main heading is 'Transaction detail'
     And the sub heading 'Suggested category' is visible
     And the sub heading 'Related unbilled transactions' is visible
-    Then I open the transaction history page
-    And the main heading is 'Transaction change history'
-    And the first event is Transaction imported from file
-    Then I go back using the link
     Then I go back using the link
     Then I go back using the link
     Then I go back using the link

--- a/cypress/integration/legacy/pas.feature
+++ b/cypress/integration/legacy/pas.feature
@@ -20,7 +20,6 @@ Feature: PAS (Installations) Legacy
     And I log which region is selected in the search bar
     And I select All for financial year in the search bar
     And I select 50 for items per page in the paging info bar
-    Then I set the temporary cessation flag for the first transaction
     Then I open the transaction detail page for the first transaction
     And the main heading is 'Transaction detail'
     And the sub heading 'Suggested category' is visible

--- a/cypress/integration/legacy/pas/pas_steps.js
+++ b/cypress/integration/legacy/pas/pas_steps.js
@@ -119,16 +119,6 @@ Then('I open the transaction detail page for the first transaction', () => {
   cy.wait('@getTransaction').its('response.statusCode').should('eq', 200)
 })
 
-Then('I open the transaction history page', () => {
-  cy.get('a.btn-outline-info').click()
-
-  cy.wait('@getTransactionHistory').its('response.statusCode').should('eq', 200)
-})
-
-And('the first event is Transaction imported from file', () => {
-  cy.get('tbody > tr:first-child > td:first-child').should('contain.text', 'Transaction imported from file')
-})
-
 Then('I go back using the link', () => {
   cy.get('.back-link').click()
 })

--- a/cypress/integration/legacy/pas/pas_steps.js
+++ b/cypress/integration/legacy/pas/pas_steps.js
@@ -113,10 +113,6 @@ And('I select {word} for items per page in the paging info bar', (option) => {
   })
 })
 
-Then('I set the temporary cessation flag for the first transaction', () => {
-  cy.get('.table-responsive > tbody > tr:first-child select.temporary-cessation-select').select('Y').should('have.value', 'true')
-})
-
 Then('I open the transaction detail page for the first transaction', () => {
   cy.get('tbody > tr:first-child button.show-details-button').click()
 

--- a/cypress/integration/legacy/wml.feature
+++ b/cypress/integration/legacy/wml.feature
@@ -21,7 +21,6 @@ Feature: WML (Installations) Legacy
     # In CFD and PAS the legacy test selects All from the financial year drop down. In WML the code is commented out.
     # This is most likely because when manually viewing the page 'All' is not an option
     And I select 50 for items per page in the paging info bar
-    Then I set the temporary cessation flag for the first transaction
     Then I open the transaction detail page for the first transaction
     And the main heading is 'Transaction detail'
     And the sub heading 'Suggested category' is visible

--- a/cypress/integration/legacy/wml.feature
+++ b/cypress/integration/legacy/wml.feature
@@ -25,10 +25,6 @@ Feature: WML (Installations) Legacy
     And the main heading is 'Transaction detail'
     And the sub heading 'Suggested category' is visible
     And the sub heading 'Related unbilled transactions' is visible
-    Then I open the transaction history page
-    And the main heading is 'Transaction change history'
-    And the first event is Transaction imported from file
-    Then I go back using the link
     Then I go back using the link
     Then I go back using the link
     Then I go back using the link

--- a/cypress/integration/legacy/wml/wml_steps.js
+++ b/cypress/integration/legacy/wml/wml_steps.js
@@ -119,16 +119,6 @@ Then('I open the transaction detail page for the first transaction', () => {
   cy.wait('@getTransaction').its('response.statusCode').should('eq', 200)
 })
 
-Then('I open the transaction history page', () => {
-  cy.get('a.btn-outline-info').click()
-
-  cy.wait('@getTransactionHistory').its('response.statusCode').should('eq', 200)
-})
-
-And('the first event is Transaction imported from file', () => {
-  cy.get('tbody > tr:first-child > td:first-child').should('contain.text', 'Transaction imported from file')
-})
-
 Then('I go back using the link', () => {
   cy.get('.back-link').click()
 })

--- a/cypress/integration/legacy/wml/wml_steps.js
+++ b/cypress/integration/legacy/wml/wml_steps.js
@@ -113,10 +113,6 @@ And('I select {word} for items per page in the paging info bar', (option) => {
   })
 })
 
-Then('I set the temporary cessation flag for the first transaction', () => {
-  cy.get('.table-responsive > tbody > tr:first-child select.temporary-cessation-select').select('Y').should('have.value', 'true')
-})
-
 Then('I open the transaction detail page for the first transaction', () => {
   cy.get('tbody > tr:first-child button.show-details-button').click()
 

--- a/cypress/integration/transactions/history.feature
+++ b/cypress/integration/transactions/history.feature
@@ -1,0 +1,15 @@
+Feature: Transaction history
+
+  Background:
+    Given I am starting with known cfd data
+    And I sign in as the 'water' user
+
+  Scenario: View import, temporary cessation and exclusion history
+    When I set the temporary cessation flag for the first transaction
+    Then exclude the first transaction
+    When I view the transaction change history
+    Then I will see Temporary Cessation is Yes
+    And I will see it has a status of To be billed and Marked for Exclusion
+    And I will see a record of its import
+    And I will see a record of its cessation
+    And I will see a record of its exclusion

--- a/cypress/integration/transactions/history/history_steps.js
+++ b/cypress/integration/transactions/history/history_steps.js
@@ -1,0 +1,45 @@
+import { And, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+import TransactionChangeHistoryPage from '../../../pages/transaction_change_history_page'
+import TransactionDetailPage from '../../../pages/transaction_detail_page'
+import TransactionsPage from '../../../pages/transactions_page'
+
+When('I set the temporary cessation flag for the first transaction', () => {
+  TransactionsPage.table.temporaryCessationSelect(0).select('Y').should('have.value', 'true')
+})
+
+Then('exclude the first transaction', () => {
+  TransactionsPage.table.showDetailsButton(0).click()
+
+  TransactionDetailPage.confirm()
+  TransactionDetailPage.excludeFromBillingButton().click()
+  TransactionDetailPage.excludeTransactionButton().click()
+})
+
+When('I view the transaction change history', () => {
+  TransactionDetailPage.viewChangeHistoryButton().click()
+
+  TransactionChangeHistoryPage.confirm()
+})
+
+Then('I will see Temporary Cessation is Yes', () => {
+  TransactionChangeHistoryPage.temporaryCessationDescription().should('have.text', 'Yes')
+})
+
+And('I will see it has a status of To be billed and Marked for Exclusion', () => {
+  TransactionChangeHistoryPage.toBeBilledBadge().should('exist')
+  TransactionChangeHistoryPage.markedForExclusionBadge().should('exist')
+})
+
+And('I will see a record of its import', () => {
+  TransactionChangeHistoryPage.table.rows().should('contain.text', 'Transaction imported from file')
+})
+
+And('I will see a record of its cessation', () => {
+  TransactionChangeHistoryPage.table.rows().should('contain.text', 'Temporary cessation changed from No to Yes')
+})
+
+And('I will see a record of its exclusion', () => {
+  TransactionChangeHistoryPage.table.rows().should('contain.text', 'Excluded from billing status changed from included to excluded')
+  TransactionChangeHistoryPage.table.rows().should('contain.text', 'Exclusion reason')
+})

--- a/cypress/pages/tables/transaction_change_history_table.js
+++ b/cypress/pages/tables/transaction_change_history_table.js
@@ -1,0 +1,37 @@
+import BaseTable from './base_table'
+
+class TransactionChangeHistoryTable extends BaseTable {
+  static cell (rowNumber, columnName) {
+    const column = this.columnPicker(columnName)
+
+    return cy.get(`.table-responsive tr:nth-child(${rowNumber + 1}) td:nth-child(${column.index})`)
+  }
+
+  static cells (columnName) {
+    const column = this.columnPicker(columnName)
+
+    return cy.get(`.table-responsive tr td:nth-child(${column.index})`)
+  }
+
+  // Support
+
+  static columns () {
+    return {
+      Event: { index: 1 },
+      When: { index: 2 },
+      Who: { index: 3 }
+    }
+  }
+
+  static columnPicker (columnName) {
+    const columns = this.columns()
+
+    if (columnName in columns) {
+      return columns[columnName]
+    }
+
+    throw new Error(`Column '${columnName}' is unknown. Check your spelling and case!`)
+  }
+}
+
+export default TransactionChangeHistoryTable

--- a/cypress/pages/transaction_change_history_page.js
+++ b/cypress/pages/transaction_change_history_page.js
@@ -1,0 +1,37 @@
+import BaseAppPage from './base_app_page'
+import TransactionChangeHistoryTable from './tables/transaction_change_history_table'
+
+class TransactionChangeHistoryPage extends BaseAppPage {
+  static get table () {
+    return TransactionChangeHistoryTable
+  }
+
+  static confirm () {
+    cy.get('h1').should('contain', 'Transaction change history')
+    cy.url().should('match', /regimes\/[a-z]{3}\/transactions\/\d*\/audit/)
+  }
+
+  // Elements
+
+  static backLink () {
+    return cy.get('a.back-link')
+  }
+
+  static customerReferenceDescription () {
+    return cy.get('dl.transaction-summary dd:nth-child(2)')
+  }
+
+  static markedForExclusionBadge () {
+    return cy.get('dl.transaction-summary dd:nth-child(28) span.badge-danger')
+  }
+
+  static toBeBilledBadge () {
+    return cy.get('dl.transaction-summary dd:nth-child(28) span.badge-primary')
+  }
+
+  static temporaryCessationDescription () {
+    return cy.get('dl.transaction-summary dd:nth-child(14)')
+  }
+}
+
+export default TransactionChangeHistoryPage


### PR DESCRIPTION
Following the same pattern as [Move legacy sort checks to their own feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/76) and [Move exclude transaction to own feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/78) this change moves the checks performed against **Transaction History** to its own feature.

We should be able to do a bit more checking there and by moving it out of the legacy tests simplify them still further.