### PR TITLE
Move legacy page export steps to new feature

### DIFF
--- a/cypress/integration/data_export/export_entries.feature
+++ b/cypress/integration/data_export/export_entries.feature
@@ -1,0 +1,22 @@
+Feature: Export matching entries
+
+  As a user of the system
+  I need to be able to export the filtered results the TCM returns
+  So that I can check and process them offline
+
+  Background:
+    Given I sign in as the 'installations' user
+
+  Scenario: Displays data protection notice when exporting
+    When I select 'Transactions to be billed' from the Transactions menu
+    And I click the export button
+    Then the data protection notice modal is displayed
+    When I select 'Transaction History' from the Transactions menu
+    And I click the export button
+    Then the data protection notice modal is displayed
+    When I select 'Pre-April 2018 Transactions to be billed' from the Transactions menu
+    And I click the export button
+    Then the data protection notice modal is displayed
+    When I select 'Excluded Transactions' from the Transactions menu
+    And I click the export button
+    Then the data protection notice modal is displayed

--- a/cypress/integration/data_export/export_entries/export_entries_steps.js
+++ b/cypress/integration/data_export/export_entries/export_entries_steps.js
@@ -1,0 +1,31 @@
+import { And, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+import TransactionsMenu from '../../../pages/menus/transactions_menu'
+
+When('I select {string} from the Transactions menu', (optionText) => {
+  TransactionsMenu.getOption(optionText, 'pas').click()
+})
+
+And('I click the export button', () => {
+  cy.get('button.table-export-btn').click()
+})
+
+Then('the data protection notice modal is displayed', () => {
+  cy.get('#data-protection-dialog')
+    .should('have.class', 'show')
+    .should('have.attr', 'aria-modal')
+  cy.get('#data-protection-dialog').should('not.have.attr', 'aria-hidden')
+
+  cy.get('#data-protection-dialog h5.modal-title')
+    .should('be.visible')
+    .should('contain.text', 'Export Transaction Data')
+
+  // TODO: Understand why we need this explicit wait() here. We've confirmed that the modal dialog is open
+  // and visible and that we can access the controls. But without this wait() we find more often than not the
+  // dialog is not dismissed when cancel is clicked which causes an error in the tests
+  cy.wait(500)
+
+  cy.get('#data-protection-dialog button.btn[data-dismiss="modal"]')
+    .should('be.visible')
+    .click()
+})

--- a/cypress/integration/legacy/cfd.feature
+++ b/cypress/integration/legacy/cfd.feature
@@ -29,7 +29,6 @@ Feature: CFD (Water Quality) Legacy
     Then I go back using the link
     Then I go back using the link
     Then I go back using the link
-    Then I click the export button and check the export modal displays
     Then I copy the consent reference from the first transaction
     And search transactions with it
     And all transactions displayed have the same consent reference
@@ -47,10 +46,8 @@ Feature: CFD (Water Quality) Legacy
     And I set pre post-sroc to Post
     And I select 'Excluded Transactions' from the Transactions menu
     And the main heading is 'Excluded Transactions'
-    Then I click the export button and check the export modal displays
     And I select 'Transaction History' from the Transactions menu
     And the main heading is 'Transaction History'
-    Then I click the export button and check the export modal displays
     Then I set view to 'Pre-April 2018 Transactions to be billed'
     And the main heading is 'Pre-April 2018 Transactions to be billed'
     # At this point in the legacy tests we set the region, clear the search field and then hit search. But with an
@@ -59,6 +56,5 @@ Feature: CFD (Water Quality) Legacy
     # selection for kicks!
     And I set retrospectives region to A
     And I grab the first record and confirm its period is pre-April 2018
-    Then I click the export button and check the export modal displays
     Then I generate the pre-sroc transaction file
     Then I see confirmation the transaction file is queued for export

--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -186,29 +186,6 @@ Then('I go back using the link', () => {
   cy.get('.back-link').click()
 })
 
-Then('I click the export button and check the export modal displays', () => {
-  cy.get('button.table-export-btn').click()
-  // NOTE: Whilst handy to confirm the dialog has appeared this is actually here to force the tests to wait for the
-  // dialog until it then tries to get() elements on it
-  cy.get('#data-protection-dialog')
-    .should('have.class', 'show')
-    .should('have.attr', 'aria-modal')
-  cy.get('#data-protection-dialog').should('not.have.attr', 'aria-hidden')
-
-  cy.get('#data-protection-dialog h5.modal-title')
-    .should('be.visible')
-    .should('contain.text', 'Export Transaction Data')
-
-  // TODO: Understand why we need this explicit wait() here. We've confirmed that the modal dialog is open
-  // and visible and that we can access the controls. But without this wait() we find more often than not the
-  // dialog is not dismissed when cancel is clicked which causes an error in the tests
-  cy.wait(500)
-
-  cy.get('#data-protection-dialog button.btn[data-dismiss="modal"]')
-    .should('be.visible')
-    .click()
-})
-
 And('approve the transactions for billing', () => {
   cy.get('button.approve-all-btn').click()
 

--- a/cypress/integration/legacy/pas.feature
+++ b/cypress/integration/legacy/pas.feature
@@ -27,7 +27,6 @@ Feature: PAS (Installations) Legacy
     Then I go back using the link
     Then I go back using the link
     Then I go back using the link
-    Then I click the export button and check the export modal displays
     Then I copy the consent reference from the first transaction
     And search transactions with it
     And all transactions displayed have the same consent reference
@@ -44,10 +43,8 @@ Feature: PAS (Installations) Legacy
     And I set pre post-sroc to All
     And I select 'Excluded Transactions' from the Transactions menu
     And the main heading is 'Excluded Transactions'
-    Then I click the export button and check the export modal displays
     And I select 'Transaction History' from the Transactions menu
     And the main heading is 'Transaction History'
-    Then I click the export button and check the export modal displays
     Then I set view to 'Pre-April 2018 Transactions to be billed'
     And the main heading is 'Pre-April 2018 Transactions to be billed'
     # At this point in the legacy tests we set the region, clear the search field and then hit search. But with an
@@ -56,6 +53,5 @@ Feature: PAS (Installations) Legacy
     # selection for kicks!
     And I set retrospectives region to A
     And I grab the first record and confirm its period is pre-April 2018
-    Then I click the export button and check the export modal displays
     Then I generate the pre-sroc transaction file
     Then I see confirmation the transaction file is queued for export

--- a/cypress/integration/legacy/pas/pas_steps.js
+++ b/cypress/integration/legacy/pas/pas_steps.js
@@ -123,29 +123,6 @@ Then('I go back using the link', () => {
   cy.get('.back-link').click()
 })
 
-Then('I click the export button and check the export modal displays', () => {
-  cy.get('button.table-export-btn').click()
-  // NOTE: Whilst handy to confirm the dialog has appeared this is actually here to force the tests to wait for the
-  // dialog until it then tries to get() elements on it
-  cy.get('#data-protection-dialog')
-    .should('have.class', 'show')
-    .should('have.attr', 'aria-modal')
-  cy.get('#data-protection-dialog').should('not.have.attr', 'aria-hidden')
-
-  cy.get('#data-protection-dialog h5.modal-title')
-    .should('be.visible')
-    .should('contain.text', 'Export Transaction Data')
-
-  // TODO: Understand why we need this explicit wait() here. We've confirmed that the modal dialog is open
-  // and visible and that we can access the controls. But without this wait() we find more often than not the
-  // dialog is not dismissed when cancel is clicked which causes an error in the tests
-  cy.wait(500)
-
-  cy.get('#data-protection-dialog button.btn[data-dismiss="modal"]')
-    .should('be.visible')
-    .click()
-})
-
 Then('I copy the consent reference from the first transaction', () => {
   cy.get('.table-responsive > tbody > tr:first-child > td').eq(4).invoke('text').then((reference) => {
     cy.wrap(reference.trim()).as('searchValue')

--- a/cypress/integration/legacy/wml.feature
+++ b/cypress/integration/legacy/wml.feature
@@ -28,7 +28,6 @@ Feature: WML (Installations) Legacy
     Then I go back using the link
     Then I go back using the link
     Then I go back using the link
-    Then I click the export button and check the export modal displays
     Then I copy the consent reference from the first transaction
     And search transactions with it
     And all transactions displayed have the same consent reference
@@ -45,7 +44,5 @@ Feature: WML (Installations) Legacy
     And I set region to A
     And I select 'Excluded Transactions' from the Transactions menu
     And the main heading is 'Excluded Transactions'
-    Then I click the export button and check the export modal displays
     And I select 'Transaction History' from the Transactions menu
     And the main heading is 'Transaction History'
-    Then I click the export button and check the export modal displays

--- a/cypress/integration/legacy/wml/wml_steps.js
+++ b/cypress/integration/legacy/wml/wml_steps.js
@@ -123,29 +123,6 @@ Then('I go back using the link', () => {
   cy.get('.back-link').click()
 })
 
-Then('I click the export button and check the export modal displays', () => {
-  cy.get('button.table-export-btn').click()
-  // NOTE: Whilst handy to confirm the dialog has appeared this is actually here to force the tests to wait for the
-  // dialog until it then tries to get() elements on it
-  cy.get('#data-protection-dialog')
-    .should('have.class', 'show')
-    .should('have.attr', 'aria-modal')
-  cy.get('#data-protection-dialog').should('not.have.attr', 'aria-hidden')
-
-  cy.get('#data-protection-dialog h5.modal-title')
-    .should('be.visible')
-    .should('contain.text', 'Export Transaction Data')
-
-  // TODO: Understand why we need this explicit wait() here. We've confirmed that the modal dialog is open
-  // and visible and that we can access the controls. But without this wait() we find more often than not the
-  // dialog is not dismissed when cancel is clicked which causes an error in the tests
-  cy.wait(500)
-
-  cy.get('#data-protection-dialog button.btn[data-dismiss="modal"]')
-    .should('be.visible')
-    .click()
-})
-
 Then('I copy the consent reference from the first transaction', () => {
   cy.get('.table-responsive > tbody > tr:first-child > td').eq(4).invoke('text').then((reference) => {
     cy.wrap(reference.trim()).as('searchValue')


### PR DESCRIPTION
This is following the same pattern as

- [Move legacy transaction history check to feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/80)
- [Move legacy sort checks to their own feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/76)
- [Move exclude transaction to own feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/78)

In the legacy tests when we get to some pages (not all!) we hit the page's export button. A feature of the TCM is its ability to download the currently filtered data to a CSV file. To clean up and simplify the legacy tests we'll move these checks to their own feature.