### PR TITLE
Add validation test

### DIFF
--- a/cypress/integration/validation/general.feature
+++ b/cypress/integration/validation/general.feature
@@ -2,7 +2,28 @@ Feature: Validation
 
     Background: Authenticate
         Given I sign in as the 'admin' user
+    
+    Scenario: Permit Category Code must be in dotted numeric format
+        When I attempt to create a permit category with an invalid code
+        Then I am told the code must be in dotted numeric format
+    
+    Scenario: Permit Category Code cannot be blank
+        When I attempt to create a permit category with a blank code
+        Then I am told the code cannot be blank
 
-    Scenario: Error message is correct
-         When I attempt to create a permit category with an invalid code
-         Then I am told the code must be in dotted numeric format
+    Scenario Outline: Permit Category Description must not include special characters
+        When I attempt to create a permit category with "<invalidCharacter>"
+        Then I am told these characters are not permitted
+          Examples:
+          | invalidCharacter |
+          | ?                |
+          | ^                |
+          | £                |
+          | ≤                |
+          | ≥                |
+          | —                |
+
+    
+    Scenario: Permit Category Description cannot be blank
+        When I attempt to create a permit category with a blank description
+        Then I am told the description cannot be blank

--- a/cypress/integration/validation/general.feature
+++ b/cypress/integration/validation/general.feature
@@ -1,0 +1,8 @@
+Feature: Validation
+
+    Background: Authenticate
+        Given I sign in as the 'admin' user
+
+    Scenario: Error message is correct
+         When I attempt to create a permit category with an invalid code
+         Then I am told the code must be in dotted numeric format

--- a/cypress/integration/validation/general/general_steps.js
+++ b/cypress/integration/validation/general/general_steps.js
@@ -1,0 +1,19 @@
+import { Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+import TransactionsPage from '../../../pages/transactions_page'
+import PermitCategoriesPage from '../../../pages/permit_categories_page'
+import AddPermitCategoryPage from '../../../pages/add_permit_category_page'
+
+When('I attempt to create a permit category with an invalid code', () => {
+  TransactionsPage.adminMenu.getOption('Permit Categories', 'pas').click()
+
+  PermitCategoriesPage.addNewPermitCategoryButton().click()
+
+  AddPermitCategoryPage.codeInput().type('QWERTY', { log: false })
+  AddPermitCategoryPage.descriptionInput().type('Test Description', { log: false })
+  AddPermitCategoryPage.submitButton().click()
+})
+
+Then('I am told the code must be in dotted numeric format', () => {
+  cy.alertShouldContain('Code Code must be in dotted numeric format, with 1 to 3 segments between 1 and 4 digits long. e.g. 6, 1.2, 9.34.1, 27.111.1234')
+})

--- a/cypress/integration/validation/general/general_steps.js
+++ b/cypress/integration/validation/general/general_steps.js
@@ -17,3 +17,43 @@ When('I attempt to create a permit category with an invalid code', () => {
 Then('I am told the code must be in dotted numeric format', () => {
   cy.alertShouldContain('Code Code must be in dotted numeric format, with 1 to 3 segments between 1 and 4 digits long. e.g. 6, 1.2, 9.34.1, 27.111.1234')
 })
+
+When('I attempt to create a permit category with a blank code', () => {
+  TransactionsPage.adminMenu.getOption('Permit Categories', 'pas').click()
+
+  PermitCategoriesPage.addNewPermitCategoryButton().click()
+
+  AddPermitCategoryPage.descriptionInput().type('Test Description', { log: false })
+  AddPermitCategoryPage.submitButton().click()
+})
+
+Then('I am told the code cannot be blank', () => {
+  cy.alertShouldContain('Code can\'t be blank')
+})
+
+When('I attempt to create a permit category with {string}', (invalidCharacter) => {
+  TransactionsPage.adminMenu.getOption('Permit Categories', 'pas').click()
+
+  PermitCategoriesPage.addNewPermitCategoryButton().click()
+
+  AddPermitCategoryPage.codeInput().type('1.5', { log: false })
+  AddPermitCategoryPage.descriptionInput().type('Test Description' + invalidCharacter, { log: false })
+  AddPermitCategoryPage.submitButton().click()
+})
+
+Then('I am told these characters are not permitted', () => {
+  cy.alertShouldContain('Description contains characters that are not permitted. Please modify your description to remove them.')
+})
+
+When('I attempt to create a permit category with a blank description', () => {
+  TransactionsPage.adminMenu.getOption('Permit Categories', 'pas').click()
+
+  PermitCategoriesPage.addNewPermitCategoryButton().click()
+
+  AddPermitCategoryPage.codeInput().type('1.5', { log: false })
+  AddPermitCategoryPage.submitButton().click()
+})
+
+Then('I am told the description cannot be blank', () => {
+  cy.alertShouldContain('Description can\'t be blank')
+})

--- a/cypress/pages/add_permit_category_page.js
+++ b/cypress/pages/add_permit_category_page.js
@@ -1,13 +1,13 @@
 import BaseAppPage from './base_app_page'
 
 class AddPermitCategoryPage extends BaseAppPage {
-    static confirm () {
-      cy.get('h1').should('contain', 'New Permit Category')
-      cy.url().should('include', '/permit_categories/new')
-    }
+  static confirm () {
+    cy.get('h1').should('contain', 'New Permit Category')
+    cy.url().should('include', '/permit_categories/new')
+  }
 
-  //Elements
-  
+  // Elements
+
   static cancelButton () {
     return cy.get('a.btn-secondary')
   }
@@ -17,9 +17,8 @@ class AddPermitCategoryPage extends BaseAppPage {
   }
 
   static descriptionInput () {
-    return cy.get('input#permit_category_description')
+    return cy.get('textarea#permit_category_description')
   }
-
 }
 
 export default AddPermitCategoryPage

--- a/cypress/pages/add_permit_category_page.js
+++ b/cypress/pages/add_permit_category_page.js
@@ -1,0 +1,25 @@
+import BaseAppPage from './base_app_page'
+
+class AddPermitCategoryPage extends BaseAppPage {
+    static confirm () {
+      cy.get('h1').should('contain', 'New Permit Category')
+      cy.url().should('include', '/permit_categories/new')
+    }
+
+  //Elements
+  
+  static cancelButton () {
+    return cy.get('a.btn-secondary')
+  }
+
+  static codeInput () {
+    return cy.get('input#permit_category_code')
+  }
+
+  static descriptionInput () {
+    return cy.get('input#permit_category_description')
+  }
+
+}
+
+export default AddPermitCategoryPage

--- a/cypress/pages/permit_categories_page.js
+++ b/cypress/pages/permit_categories_page.js
@@ -9,15 +9,12 @@ class PermitCategoriesPage extends BaseAppPage {
   // Elements
 
   static searchCodeInput () {
-      return cy.get('input#search[type="search"]')
+    return cy.get('input#search[type="search"]')
   }
 
   static addNewPermitCategoryButton () {
     return cy.get('button#new-category')
   }
-
-
-
 }
 
 export default PermitCategoriesPage

--- a/cypress/pages/permit_categories_page.js
+++ b/cypress/pages/permit_categories_page.js
@@ -1,0 +1,23 @@
+import BaseAppPage from './base_app_page'
+
+class PermitCategoriesPage extends BaseAppPage {
+  static confirm () {
+    cy.get('h1').should('contain', 'Permit Categories')
+    cy.url().should('include', '/permit_categories')
+  }
+
+  // Elements
+
+  static searchCodeInput () {
+      return cy.get('input#search[type="search"]')
+  }
+
+  static addNewPermitCategoryButton () {
+    return cy.get('button#new-category')
+  }
+
+
+
+}
+
+export default PermitCategoriesPage


### PR DESCRIPTION
This change [CMEA-300](https://eaflood.atlassian.net/browse/CMEA-300) covers testing for a bug fix in how the TCM displays error messages [CMEA-293](https://eaflood.atlassian.net/browse/CMEA-293). These new test scenarios cover validation and error message responses in the Add Permit Category area of the TCM. Scope of validation includes: 

- Error messages for invalid Permit Category Code 
- Error messages for invalid Permit Category Description

