### PR TITLE
Move legacy page checking steps to new feature

### DIFF
--- a/cypress/integration/email/expired_tokens/expired_tokens_steps.js
+++ b/cypress/integration/email/expired_tokens/expired_tokens_steps.js
@@ -1,6 +1,6 @@
 import { And, But, Then, When } from 'cypress-cucumber-preprocessor/steps'
 
-import ChangePasswordPage from '../../../pages/change_password_page'
+import ForgotPasswordConfirmPage from '../../../pages/forgot_password_confirm_page'
 import ForgotPasswordPage from '../../../pages/forgot_password_page'
 import LastEmailPage from '../../../pages/last_email_page'
 import ResendUnlockPage from '../../../pages/resend_unlock_page'
@@ -51,11 +51,11 @@ And('I try to accept the first unlock email', () => {
 When('I try to accept the first reset password email', () => {
   cy.get('@firstLink').then((firstLink) => {
     cy.visit(firstLink).then(() => {
-      ChangePasswordPage.confirm()
+      ForgotPasswordConfirmPage.confirm()
 
-      ChangePasswordPage.passwordInput().type(Cypress.env('PASSWORD'), { log: false })
-      ChangePasswordPage.passwordConfirmationInput().type(Cypress.env('PASSWORD'), { log: false })
-      ChangePasswordPage.submitButton().click()
+      ForgotPasswordConfirmPage.passwordInput().type(Cypress.env('PASSWORD'), { log: false })
+      ForgotPasswordConfirmPage.passwordConfirmationInput().type(Cypress.env('PASSWORD'), { log: false })
+      ForgotPasswordConfirmPage.submitButton().click()
     })
   })
 })

--- a/cypress/integration/email/general/general_steps.js
+++ b/cypress/integration/email/general/general_steps.js
@@ -1,6 +1,6 @@
 import { When } from 'cypress-cucumber-preprocessor/steps'
 
-import ChangePasswordPage from '../../../pages/change_password_page'
+import ForgotPasswordConfirmPage from '../../../pages/forgot_password_confirm_page'
 import LastEmailPage from '../../../pages/last_email_page'
 
 When('I follow the link to reset my password', () => {
@@ -11,11 +11,11 @@ When('I follow the link to reset my password', () => {
       const link = LastEmailPage.extractResetPasswordLink(lastEmail.last_email.body)
 
       cy.visit(link).then(() => {
-        ChangePasswordPage.confirm()
+        ForgotPasswordConfirmPage.confirm()
 
-        ChangePasswordPage.passwordInput().type(Cypress.env('PASSWORD'), { log: false })
-        ChangePasswordPage.passwordConfirmationInput().type(Cypress.env('PASSWORD'), { log: false })
-        ChangePasswordPage.submitButton().click()
+        ForgotPasswordConfirmPage.passwordInput().type(Cypress.env('PASSWORD'), { log: false })
+        ForgotPasswordConfirmPage.passwordConfirmationInput().type(Cypress.env('PASSWORD'), { log: false })
+        ForgotPasswordConfirmPage.submitButton().click()
       })
     })
   })

--- a/cypress/integration/legacy/cfd.feature
+++ b/cypress/integration/legacy/cfd.feature
@@ -33,15 +33,7 @@ Feature: CFD (Water Quality) Legacy
     Then I see confirmation the transaction file is queued for export
     And I log the transaction filename to prove it can be used in another step
     And there are no transactions to be billed displayed anymore
-    And I select 'Transaction File History' from the Transactions menu
-    And the main heading is 'Transaction File History'
-    And I set region to A
-    And I set pre post-sroc to Post
-    And I select 'Excluded Transactions' from the Transactions menu
-    And the main heading is 'Excluded Transactions'
-    And I select 'Transaction History' from the Transactions menu
-    And the main heading is 'Transaction History'
-    Then I set view to 'Pre-April 2018 Transactions to be billed'
+    And I select 'Pre-April 2018 Transactions to be billed' from the Transactions menu
     And the main heading is 'Pre-April 2018 Transactions to be billed'
     # At this point in the legacy tests we set the region, clear the search field and then hit search. But with an
     # automates test this does nothing. Region A is already selected and the search field is already empty. So, clicking

--- a/cypress/integration/legacy/cfd/cfd_steps.js
+++ b/cypress/integration/legacy/cfd/cfd_steps.js
@@ -232,26 +232,8 @@ And('I log the transaction filename to prove it can be used in another step', ()
     .then(filename => cy.log(filename))
 })
 
-And('I set region to {word}', (option) => {
-  cy.get('select#region').select(option)
-
-  cy.wait('@getTransactionFileHistory').its('response.statusCode').should('eq', 200)
-})
-
 And('I set retrospectives region to {word}', (option) => {
   cy.get('select#region').select(option)
-
-  cy.wait('@getRetrospectivesSearch').its('response.statusCode').should('eq', 200)
-})
-
-And('I set pre post-sroc to {word}', (option) => {
-  cy.get('select#prepost').select(option)
-
-  cy.wait('@getTransactionFileHistory').its('response.statusCode').should('eq', 200)
-})
-
-Then('I set view to {string}', (option) => {
-  cy.get('select#mode').select(option)
 
   cy.wait('@getRetrospectivesSearch').its('response.statusCode').should('eq', 200)
 })

--- a/cypress/integration/legacy/pas.feature
+++ b/cypress/integration/legacy/pas.feature
@@ -30,15 +30,7 @@ Feature: PAS (Installations) Legacy
     And generate the transaction file
     Then I see confirmation the transaction file is queued for export
     And there are no transactions to be billed displayed anymore
-    And I select 'Transaction File History' from the Transactions menu
-    And the main heading is 'Transaction File History'
-    And I set region to A
-    And I set pre post-sroc to All
-    And I select 'Excluded Transactions' from the Transactions menu
-    And the main heading is 'Excluded Transactions'
-    And I select 'Transaction History' from the Transactions menu
-    And the main heading is 'Transaction History'
-    Then I set view to 'Pre-April 2018 Transactions to be billed'
+    And I select 'Pre-April 2018 Transactions to be billed' from the Transactions menu
     And the main heading is 'Pre-April 2018 Transactions to be billed'
     # At this point in the legacy tests we set the region, clear the search field and then hit search. But with an
     # automates test this does nothing. Region A is already selected and the search field is already empty. So, clicking

--- a/cypress/integration/legacy/pas/pas_steps.js
+++ b/cypress/integration/legacy/pas/pas_steps.js
@@ -205,24 +205,6 @@ Then('there are no transactions to be billed displayed anymore', () => {
   cy.get('.table-responsive > tbody > tr').should('not.exist')
 })
 
-And('I set region to {word}', (option) => {
-  cy.get('select#region').select(option)
-
-  cy.wait('@getTransactionFileHistory').its('response.statusCode').should('eq', 200)
-})
-
-And('I set pre post-sroc to {word}', (option) => {
-  cy.get('select#prepost').select(option)
-
-  cy.wait('@getTransactionFileHistory').its('response.statusCode').should('eq', 200)
-})
-
-Then('I set view to {string}', (option) => {
-  cy.get('select#mode').select(option)
-
-  cy.wait('@getRetrospectivesSearch').its('response.statusCode').should('eq', 200)
-})
-
 And('I set retrospectives region to {word}', (option) => {
   cy.get('select#region').select(option)
 

--- a/cypress/integration/legacy/wml.feature
+++ b/cypress/integration/legacy/wml.feature
@@ -32,10 +32,3 @@ Feature: WML (Installations) Legacy
     And generate the transaction file
     Then I see confirmation the transaction file is queued for export
     And there are no transactions to be billed displayed anymore
-    And I select 'Transaction File History' from the Transactions menu
-    And the main heading is 'Transaction File History'
-    And I set region to A
-    And I select 'Excluded Transactions' from the Transactions menu
-    And the main heading is 'Excluded Transactions'
-    And I select 'Transaction History' from the Transactions menu
-    And the main heading is 'Transaction History'

--- a/cypress/integration/legacy/wml/wml_steps.js
+++ b/cypress/integration/legacy/wml/wml_steps.js
@@ -204,9 +204,3 @@ Then('I see confirmation the transaction file is queued for export', () => {
 Then('there are no transactions to be billed displayed anymore', () => {
   cy.get('.table-responsive > tbody > tr').should('not.exist')
 })
-
-And('I set region to {word}', (option) => {
-  cy.get('select#region').select(option)
-
-  cy.wait('@getTransactionFileHistory').its('response.statusCode').should('eq', 200)
-})

--- a/cypress/integration/smoke/general.feature
+++ b/cypress/integration/smoke/general.feature
@@ -20,6 +20,10 @@ Feature: Smoke test
     Then I see the Transaction File History page
     And I select 'Download Transaction Data' from the Transactions menu
     Then I see the Download Transaction Data page
+    And I select 'Permit Categories' from the Admin menu
+    Then I see the Permit Categories page
+    And I select 'Exclusion Reasons' from the Admin menu
+    Then I see the Exclusion Reasons page
 
   Scenario: Page checks (PAS)
     When I select the 'Installations' regime
@@ -38,6 +42,10 @@ Feature: Smoke test
     Then I see the Transaction File History page
     And I select 'Download Transaction Data' from the Transactions menu
     Then I see the Download Transaction Data page
+    And I select 'Permit Categories' from the Admin menu
+    Then I see the Permit Categories page
+    And I select 'Exclusion Reasons' from the Admin menu
+    Then I see the Exclusion Reasons page
 
   Scenario: Page checks (WML)
     When I select the 'Waste' regime
@@ -54,3 +62,7 @@ Feature: Smoke test
     Then I see the Transaction File History page
     And I select 'Download Transaction Data' from the Transactions menu
     Then I see the Download Transaction Data page
+    And I select 'Permit Categories' from the Admin menu
+    Then I see the Permit Categories page
+    And I select 'Exclusion Reasons' from the Admin menu
+    Then I see the Exclusion Reasons page

--- a/cypress/integration/smoke/general.feature
+++ b/cypress/integration/smoke/general.feature
@@ -74,3 +74,15 @@ Feature: Smoke test
     Then I see the Permit Categories page
     And I select 'Review Annual Billing Data' from the Annual Billing menu
     Then I see the Annual Billing Data Files page
+
+  Scenario: Page checks (Users)
+    And from the Admin menu I select User Management
+    Then I see the Users page
+    And from the User menu I select Change Password
+    Then I see the Change Password page
+    When I sign out
+    Then I see the Sign in page
+    When I click the Forgot your password link
+    Then I see the Forgot your password page
+    When I click the resend unlock instructions link
+    Then I see the Resend unlock instructions page

--- a/cypress/integration/smoke/general.feature
+++ b/cypress/integration/smoke/general.feature
@@ -1,0 +1,56 @@
+Feature: Smoke test
+
+  Background:
+    Given I sign in as the 'admin' user
+
+  Scenario: Page checks (CFD)
+    When I select the 'Water Quality' regime
+    Then I see the Transactions to be billed page
+    And I select 'Transactions to be billed' from the Transactions menu
+    Then I see the Transactions to be billed page
+    And I select 'Transaction History' from the Transactions menu
+    Then I see the Transaction History page
+    And I select 'Pre-April 2018 Transactions to be billed' from the Transactions menu
+    Then I see the Pre-April 2018 Transactions to be billed page
+    And I select 'Excluded Transactions' from the Transactions menu
+    Then I see the Excluded Transactions page
+    And I select 'Imported Transaction Files' from the Transactions menu
+    Then I see the Imported Transaction Files page
+    And I select 'Transaction File History' from the Transactions menu
+    Then I see the Transaction File History page
+    And I select 'Download Transaction Data' from the Transactions menu
+    Then I see the Download Transaction Data page
+
+  Scenario: Page checks (PAS)
+    When I select the 'Installations' regime
+    Then I see the Transactions to be billed page
+    And I select 'Transactions to be billed' from the Transactions menu
+    Then I see the Transactions to be billed page
+    And I select 'Transaction History' from the Transactions menu
+    Then I see the Transaction History page
+    And I select 'Pre-April 2018 Transactions to be billed' from the Transactions menu
+    Then I see the Pre-April 2018 Transactions to be billed page
+    And I select 'Excluded Transactions' from the Transactions menu
+    Then I see the Excluded Transactions page
+    And I select 'Imported Transaction Files' from the Transactions menu
+    Then I see the Imported Transaction Files page
+    And I select 'Transaction File History' from the Transactions menu
+    Then I see the Transaction File History page
+    And I select 'Download Transaction Data' from the Transactions menu
+    Then I see the Download Transaction Data page
+
+  Scenario: Page checks (WML)
+    When I select the 'Waste' regime
+    Then I see the Transactions to be billed page
+    And I select 'Transactions to be billed' from the Transactions menu
+    Then I see the Transactions to be billed page
+    And I select 'Transaction History' from the Transactions menu
+    Then I see the Transaction History page
+    And I select 'Excluded Transactions' from the Transactions menu
+    Then I see the Excluded Transactions page
+    And I select 'Imported Transaction Files' from the Transactions menu
+    Then I see the Imported Transaction Files page
+    And I select 'Transaction File History' from the Transactions menu
+    Then I see the Transaction File History page
+    And I select 'Download Transaction Data' from the Transactions menu
+    Then I see the Download Transaction Data page

--- a/cypress/integration/smoke/general.feature
+++ b/cypress/integration/smoke/general.feature
@@ -24,6 +24,8 @@ Feature: Smoke test
     Then I see the Permit Categories page
     And I select 'Exclusion Reasons' from the Admin menu
     Then I see the Exclusion Reasons page
+    And I select 'Review Annual Billing Data' from the Annual Billing menu
+    Then I see the Annual Billing Data Files page
 
   Scenario: Page checks (PAS)
     When I select the 'Installations' regime
@@ -46,6 +48,8 @@ Feature: Smoke test
     Then I see the Permit Categories page
     And I select 'Exclusion Reasons' from the Admin menu
     Then I see the Exclusion Reasons page
+    And I select 'Review Annual Billing Data' from the Annual Billing menu
+    Then I see the Annual Billing Data Files page
 
   Scenario: Page checks (WML)
     When I select the 'Waste' regime
@@ -66,3 +70,7 @@ Feature: Smoke test
     Then I see the Permit Categories page
     And I select 'Exclusion Reasons' from the Admin menu
     Then I see the Exclusion Reasons page
+    And I select 'Permit Categories' from the Admin menu
+    Then I see the Permit Categories page
+    And I select 'Review Annual Billing Data' from the Annual Billing menu
+    Then I see the Annual Billing Data Files page

--- a/cypress/integration/smoke/general/general_steps.js
+++ b/cypress/integration/smoke/general/general_steps.js
@@ -3,8 +3,10 @@ import { And, Then } from 'cypress-cucumber-preprocessor/steps'
 import MainMenu from '../../../pages/menus/main_menu'
 
 import ExcludedTransactionsPage from '../../../pages/excluded_transactions_page'
+import ExclusionReasonsPage from '../../../pages/exclusion_reasons_page'
 import ExportDataPage from '../../../pages/export_data_page'
 import ImportedTransactionFilesPage from '../../../pages/imported_transaction_files_page'
+import PermitCategoriesPage from '../../../pages/permit_categories_page'
 import RetrospectiveTransactionsPage from '../../../pages/retrospective_transactions_page'
 import TransactionFileHistoryPage from '../../../pages/transaction_file_history_page'
 import TransactionsPage from '../../../pages/transactions_page'
@@ -13,6 +15,12 @@ import TransactionHistoryPage from '../../../pages/transaction_history_page'
 And('I select {string} from the Transactions menu', (optionText) => {
   cy.get('@regime').then((regime) => {
     MainMenu.transactions.getOption(optionText, regime.slug).click()
+  })
+})
+
+And('I select {string} from the Admin menu', (optionText) => {
+  cy.get('@regime').then((regime) => {
+    MainMenu.admin.getOption(optionText, regime.slug).click()
   })
 })
 
@@ -42,4 +50,12 @@ Then('I see the Transaction File History page', () => {
 
 Then('I see the Download Transaction Data page', () => {
   ExportDataPage.confirm()
+})
+
+Then('I see the Permit Categories page', () => {
+  PermitCategoriesPage.confirm()
+})
+
+Then('I see the Exclusion Reasons page', () => {
+  ExclusionReasonsPage.confirm()
 })

--- a/cypress/integration/smoke/general/general_steps.js
+++ b/cypress/integration/smoke/general/general_steps.js
@@ -1,17 +1,22 @@
-import { And, Then } from 'cypress-cucumber-preprocessor/steps'
+import { And, Then, When } from 'cypress-cucumber-preprocessor/steps'
 
 import MainMenu from '../../../pages/menus/main_menu'
 
 import AnnualBillingPage from '../../../pages/annual_billing_page'
+import ChangePasswordPage from '../../../pages/change_password_page'
 import ExcludedTransactionsPage from '../../../pages/excluded_transactions_page'
 import ExclusionReasonsPage from '../../../pages/exclusion_reasons_page'
 import ExportDataPage from '../../../pages/export_data_page'
+import ForgotPasswordPage from '../../../pages/forgot_password_page'
 import ImportedTransactionFilesPage from '../../../pages/imported_transaction_files_page'
 import PermitCategoriesPage from '../../../pages/permit_categories_page'
+import ResendUnlockPage from '../../../pages/resend_unlock_page'
 import RetrospectiveTransactionsPage from '../../../pages/retrospective_transactions_page'
+import SignInPage from '../../../pages/sign_in_page'
 import TransactionFileHistoryPage from '../../../pages/transaction_file_history_page'
 import TransactionsPage from '../../../pages/transactions_page'
 import TransactionHistoryPage from '../../../pages/transaction_history_page'
+import UsersPage from '../../../pages/users_page'
 
 And('I select {string} from the Transactions menu', (optionText) => {
   cy.get('@regime').then((regime) => {
@@ -29,6 +34,26 @@ And('I select {string} from the Annual Billing menu', (optionText) => {
   cy.get('@regime').then((regime) => {
     MainMenu.annualBilling.getOption(optionText, regime.slug).click()
   })
+})
+
+And('from the Admin menu I select User Management', () => {
+  MainMenu.admin.getOption('User Management', '').click()
+})
+
+And('from the User menu I select Change Password', () => {
+  MainMenu.user.getOption('Change Password').click()
+})
+
+When('I sign out', () => {
+  cy.signOut()
+})
+
+When('I click the Forgot your password link', () => {
+  SignInPage.forgotPasswordLink().click()
+})
+
+When('I click the resend unlock instructions link', () => {
+  SignInPage.resendUnlockLink().click()
 })
 
 Then('I see the Transactions to be billed page', () => {
@@ -69,4 +94,24 @@ Then('I see the Exclusion Reasons page', () => {
 
 Then('I see the Annual Billing Data Files page', () => {
   AnnualBillingPage.confirm()
+})
+
+Then('I see the Users page', () => {
+  UsersPage.confirm()
+})
+
+Then('I see the Change Password page', () => {
+  ChangePasswordPage.confirm()
+})
+
+Then('I see the Sign in page', () => {
+  SignInPage.confirm()
+})
+
+Then('I see the Forgot your password page', () => {
+  ForgotPasswordPage.confirm()
+})
+
+Then('I see the Resend unlock instructions page', () => {
+  ResendUnlockPage.confirm()
 })

--- a/cypress/integration/smoke/general/general_steps.js
+++ b/cypress/integration/smoke/general/general_steps.js
@@ -2,6 +2,7 @@ import { And, Then } from 'cypress-cucumber-preprocessor/steps'
 
 import MainMenu from '../../../pages/menus/main_menu'
 
+import AnnualBillingPage from '../../../pages/annual_billing_page'
 import ExcludedTransactionsPage from '../../../pages/excluded_transactions_page'
 import ExclusionReasonsPage from '../../../pages/exclusion_reasons_page'
 import ExportDataPage from '../../../pages/export_data_page'
@@ -21,6 +22,12 @@ And('I select {string} from the Transactions menu', (optionText) => {
 And('I select {string} from the Admin menu', (optionText) => {
   cy.get('@regime').then((regime) => {
     MainMenu.admin.getOption(optionText, regime.slug).click()
+  })
+})
+
+And('I select {string} from the Annual Billing menu', (optionText) => {
+  cy.get('@regime').then((regime) => {
+    MainMenu.annualBilling.getOption(optionText, regime.slug).click()
   })
 })
 
@@ -58,4 +65,8 @@ Then('I see the Permit Categories page', () => {
 
 Then('I see the Exclusion Reasons page', () => {
   ExclusionReasonsPage.confirm()
+})
+
+Then('I see the Annual Billing Data Files page', () => {
+  AnnualBillingPage.confirm()
 })

--- a/cypress/integration/smoke/general/general_steps.js
+++ b/cypress/integration/smoke/general/general_steps.js
@@ -1,0 +1,45 @@
+import { And, Then } from 'cypress-cucumber-preprocessor/steps'
+
+import MainMenu from '../../../pages/menus/main_menu'
+
+import ExcludedTransactionsPage from '../../../pages/excluded_transactions_page'
+import ExportDataPage from '../../../pages/export_data_page'
+import ImportedTransactionFilesPage from '../../../pages/imported_transaction_files_page'
+import RetrospectiveTransactionsPage from '../../../pages/retrospective_transactions_page'
+import TransactionFileHistoryPage from '../../../pages/transaction_file_history_page'
+import TransactionsPage from '../../../pages/transactions_page'
+import TransactionHistoryPage from '../../../pages/transaction_history_page'
+
+And('I select {string} from the Transactions menu', (optionText) => {
+  cy.get('@regime').then((regime) => {
+    MainMenu.transactions.getOption(optionText, regime.slug).click()
+  })
+})
+
+Then('I see the Transactions to be billed page', () => {
+  TransactionsPage.confirm()
+})
+
+Then('I see the Transaction History page', () => {
+  TransactionHistoryPage.confirm()
+})
+
+Then('I see the Pre-April 2018 Transactions to be billed page', () => {
+  RetrospectiveTransactionsPage.confirm()
+})
+
+Then('I see the Excluded Transactions page', () => {
+  ExcludedTransactionsPage.confirm()
+})
+
+Then('I see the Imported Transaction Files page', () => {
+  ImportedTransactionFilesPage.confirm()
+})
+
+Then('I see the Transaction File History page', () => {
+  TransactionFileHistoryPage.confirm()
+})
+
+Then('I see the Download Transaction Data page', () => {
+  ExportDataPage.confirm()
+})

--- a/cypress/pages/add_permit_category_page.js
+++ b/cypress/pages/add_permit_category_page.js
@@ -3,7 +3,7 @@ import BaseAppPage from './base_app_page'
 class AddPermitCategoryPage extends BaseAppPage {
   static confirm () {
     cy.get('h1').should('contain', 'New Permit Category')
-    cy.url().should('include', '/permit_categories/new')
+    cy.url().should('match', /regimes\/[a-z]{3}\/permit_categories\/new/)
   }
 
   // Elements

--- a/cypress/pages/annual_billing_file_details_page.js
+++ b/cypress/pages/annual_billing_file_details_page.js
@@ -3,7 +3,7 @@ import BaseAppPage from './base_app_page'
 class AnnualBillingFileDetailsPage extends BaseAppPage {
   static confirm () {
     cy.get('h1').should('contain', 'Annual Billing Data File Details')
-    cy.url().should('include', '/annual_billing_data_files')
+    cy.url().should('match', /regimes\/[a-z]{3}\/annual_billing_data_files\/\d*/)
   }
 
   // Elements

--- a/cypress/pages/annual_billing_page.js
+++ b/cypress/pages/annual_billing_page.js
@@ -3,7 +3,7 @@ import BaseAppPage from './base_app_page'
 class AnnualBillingPage extends BaseAppPage {
   static confirm () {
     cy.get('h1').should('contain', 'Annual Billing Data Files')
-    cy.url().should('include', '/annual_billing_data_files')
+    cy.url().should('match', /regimes\/[a-z]{3}\/annual_billing_data_files/)
   }
 
   // Elements

--- a/cypress/pages/change_password_page.js
+++ b/cypress/pages/change_password_page.js
@@ -1,0 +1,10 @@
+import BaseAppPage from './base_app_page'
+
+class ChangePasswordPage extends BaseAppPage {
+  static confirm () {
+    cy.get('h1').should('contain', 'Change your password')
+    cy.url().should('include', '/change_password/edit')
+  }
+}
+
+export default ChangePasswordPage

--- a/cypress/pages/excluded_transactions_page.js
+++ b/cypress/pages/excluded_transactions_page.js
@@ -1,0 +1,10 @@
+import BaseAppPage from './base_app_page'
+
+class ExcludedTransactionsPage extends BaseAppPage {
+  static confirm () {
+    cy.get('h1').should('contain', 'Excluded Transactions')
+    cy.url().should('match', /regimes\/[a-z]{3}\/exclusions/)
+  }
+}
+
+export default ExcludedTransactionsPage

--- a/cypress/pages/exclusion_reasons_page.js
+++ b/cypress/pages/exclusion_reasons_page.js
@@ -1,0 +1,10 @@
+import BaseAppPage from './base_app_page'
+
+class ExclusionReasonsPage extends BaseAppPage {
+  static confirm () {
+    cy.get('h1').should('contain', 'Exclusion Reasons')
+    cy.url().should('match', /regimes\/[a-z]{3}\/exclusion_reasons/)
+  }
+}
+
+export default ExclusionReasonsPage

--- a/cypress/pages/export_data_page.js
+++ b/cypress/pages/export_data_page.js
@@ -3,7 +3,7 @@ import BaseAppPage from './base_app_page'
 class ExportDataPage extends BaseAppPage {
   static confirm () {
     cy.get('h1').should('contain', 'Download Transaction Data')
-    cy.url().should('include', '/data_export')
+    cy.url().should('match', /regimes\/[a-z]{3}\/data_export/)
   }
 
   // Elements

--- a/cypress/pages/forgot_password_confirm_page.js
+++ b/cypress/pages/forgot_password_confirm_page.js
@@ -1,6 +1,6 @@
 import BasePage from './base_page'
 
-class ChangePasswordPage extends BasePage {
+class ForgotPasswordConfirmPage extends BasePage {
   static confirm () {
     cy.get('h1').should('contain', 'Change your password')
     cy.url().should('include', '/auth/password')
@@ -17,4 +17,4 @@ class ChangePasswordPage extends BasePage {
   }
 }
 
-export default ChangePasswordPage
+export default ForgotPasswordConfirmPage

--- a/cypress/pages/imported_transaction_files_page.js
+++ b/cypress/pages/imported_transaction_files_page.js
@@ -1,0 +1,10 @@
+import BaseAppPage from './base_app_page'
+
+class ImportedTransactionFilesPage extends BaseAppPage {
+  static confirm () {
+    cy.get('h1').should('contain', 'Imported Transaction Files')
+    cy.url().should('match', /regimes\/[a-z]{3}\/imported_transaction_files/)
+  }
+}
+
+export default ImportedTransactionFilesPage

--- a/cypress/pages/menus/main_menu.js
+++ b/cypress/pages/menus/main_menu.js
@@ -1,4 +1,5 @@
 import AdminMenu from './admin_menu'
+import AnnualBillingMenu from './annual_billing_menu'
 import RegimeMenu from './regime_menu'
 import TransactionsMenu from './transactions_menu'
 import UserMenu from './user_menu'
@@ -6,6 +7,10 @@ import UserMenu from './user_menu'
 class MainMenu {
   static get admin () {
     return AdminMenu
+  }
+
+  static get annualBilling () {
+    return AnnualBillingMenu
   }
 
   static get regime () {

--- a/cypress/pages/permit_categories_page.js
+++ b/cypress/pages/permit_categories_page.js
@@ -3,7 +3,7 @@ import BaseAppPage from './base_app_page'
 class PermitCategoriesPage extends BaseAppPage {
   static confirm () {
     cy.get('h1').should('contain', 'Permit Categories')
-    cy.url().should('include', '/permit_categories')
+    cy.url().should('match', /regimes\/[a-z]{3}\/permit_categories/)
   }
 
   // Elements

--- a/cypress/pages/retrospective_transactions_page.js
+++ b/cypress/pages/retrospective_transactions_page.js
@@ -1,0 +1,10 @@
+import BaseAppPage from './base_app_page'
+
+class RetrospectiveTransactionsPage extends BaseAppPage {
+  static confirm () {
+    cy.get('h1').should('contain', 'Pre-April 2018 Transactions to be billed')
+    cy.url().should('match', /regimes\/[a-z]{3}\/retrospectives/)
+  }
+}
+
+export default RetrospectiveTransactionsPage

--- a/cypress/pages/transaction_file_history_page.js
+++ b/cypress/pages/transaction_file_history_page.js
@@ -1,0 +1,10 @@
+import BaseAppPage from './base_app_page'
+
+class TransactionFileHistoryPage extends BaseAppPage {
+  static confirm () {
+    cy.get('h1').should('contain', 'Transaction File History')
+    cy.url().should('match', /regimes\/[a-z]{3}\/transaction_files/)
+  }
+}
+
+export default TransactionFileHistoryPage

--- a/cypress/pages/transaction_history_page.js
+++ b/cypress/pages/transaction_history_page.js
@@ -1,0 +1,10 @@
+import BaseAppPage from './base_app_page'
+
+class TransactionHistoryPage extends BaseAppPage {
+  static confirm () {
+    cy.get('h1').should('contain', 'Transaction History')
+    cy.url().should('match', /regimes\/[a-z]{3}\/history/)
+  }
+}
+
+export default TransactionHistoryPage


### PR DESCRIPTION
This is following the same pattern as

- [Move legacy transaction history check to feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/80)
- [Move legacy sort checks to their own feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/76)
- [Move exclude transaction to own feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/78)
- [Move legacy page export steps to new feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/82)
- [Move legacy transaction detail steps to new feature](https://github.com/DEFRA/sroc-acceptance-tests/pull/83)

The legacy tests don't do anything more than check that if you go to a page the title is as expected. But it does add noise to the key thing the legacy tests are checking; updating a transaction to the point it can be exported for invoicing.

So, we move them to their own feature.