### PR TITLE
Expand transaction data file download feature

### DIFF
--- a/cypress/integration/data_export/general.feature
+++ b/cypress/integration/data_export/general.feature
@@ -18,3 +18,4 @@ Feature: Data Export
     And I proceed to view the file download details
     Then I can download transaction data file
     And the transaction data file exists
+    And it contains the data I expect

--- a/cypress/integration/data_export/general.feature
+++ b/cypress/integration/data_export/general.feature
@@ -1,10 +1,19 @@
 Feature: Data Export
 
   Background:
-    Given I sign in as the 'admin' user
+    Given I am starting with known data
+      And I sign in as the 'admin' user
+
+  Scenario: No transaction file has been generated
+     When I select the 'Installations' regime
+      And I proceed to view the file download details
+     Then I can view the Data Protection Notice
+      And I am told that the transaction file has not yet been generated
+      And I cannot download transaction data
 
   Scenario: Download transaction data
-    When I select the 'Installations' regime
-    And I proceed to view file download details
-    Then I can view the Data Protection Notice
-    And I can download transaction data
+     When I select the 'Installations' regime
+      And I proceed to view the file download details
+      And I run the generate data job
+     Then I can download transaction data 
+      And the downloaded transaction file includes known data

--- a/cypress/integration/data_export/general.feature
+++ b/cypress/integration/data_export/general.feature
@@ -2,18 +2,20 @@ Feature: Data Export
 
   Background:
     Given I am starting with known data
-    And I sign in as the 'admin' user
 
   Scenario: No transaction file has been generated
-    When I select the 'Installations' regime
+    When I sign in as the 'admin' user
+    And I select the 'Installations' regime
     And I proceed to view the file download details
     Then I can view the Data Protection Notice
     And I am told that the transaction data file has not yet been generated
     And I cannot download transaction data
 
+  @wip
   Scenario: Download transaction data
-    When I select the 'Installations' regime
-    And I proceed to view the file download details
-    And I run the generate data job
-    Then I can download transaction data
-    And the downloaded transaction file includes known data
+    When I run the generate data job
+    And I sign in as the 'admin' user
+    And I select the 'Installations' regime
+    When I proceed to view the file download details
+    Then I can download transaction data file
+    And the transaction data file exists

--- a/cypress/integration/data_export/general.feature
+++ b/cypress/integration/data_export/general.feature
@@ -8,7 +8,7 @@ Feature: Data Export
     When I select the 'Installations' regime
     And I proceed to view the file download details
     Then I can view the Data Protection Notice
-    And I am told that the transaction file has not yet been generated
+    And I am told that the transaction data file has not yet been generated
     And I cannot download transaction data
 
   Scenario: Download transaction data

--- a/cypress/integration/data_export/general.feature
+++ b/cypress/integration/data_export/general.feature
@@ -2,10 +2,10 @@ Feature: Data Export
 
   Background:
     Given I am starting with known data
+    And I sign in as the 'admin' user
 
   Scenario: No transaction file has been generated
-    When I sign in as the 'admin' user
-    And I select the 'Installations' regime
+    When I select the 'Installations' regime
     And I proceed to view the file download details
     Then I can view the Data Protection Notice
     And I am told that the transaction data file has not yet been generated
@@ -14,8 +14,8 @@ Feature: Data Export
   @wip
   Scenario: Download transaction data
     When I run the generate data job
-    And I sign in as the 'admin' user
-    And I select the 'Installations' regime
-    When I proceed to view the file download details
+    And return to the home page
+    When I select the 'Installations' regime
+    And I proceed to view the file download details
     Then I can download transaction data file
     And the transaction data file exists

--- a/cypress/integration/data_export/general.feature
+++ b/cypress/integration/data_export/general.feature
@@ -2,18 +2,18 @@ Feature: Data Export
 
   Background:
     Given I am starting with known data
-      And I sign in as the 'admin' user
+    And I sign in as the 'admin' user
 
   Scenario: No transaction file has been generated
-     When I select the 'Installations' regime
-      And I proceed to view the file download details
-     Then I can view the Data Protection Notice
-      And I am told that the transaction file has not yet been generated
-      And I cannot download transaction data
+    When I select the 'Installations' regime
+    And I proceed to view the file download details
+    Then I can view the Data Protection Notice
+    And I am told that the transaction file has not yet been generated
+    And I cannot download transaction data
 
   Scenario: Download transaction data
-     When I select the 'Installations' regime
-      And I proceed to view the file download details
-      And I run the generate data job
-     Then I can download transaction data 
-      And the downloaded transaction file includes known data
+    When I select the 'Installations' regime
+    And I proceed to view the file download details
+    And I run the generate data job
+    Then I can download transaction data
+    And the downloaded transaction file includes known data

--- a/cypress/integration/data_export/general.feature
+++ b/cypress/integration/data_export/general.feature
@@ -11,7 +11,6 @@ Feature: Data Export
     And I am told that the transaction data file has not yet been generated
     And I cannot download transaction data
 
-  @wip
   Scenario: Download transaction data
     When I run the generate data job
     And return to the home page

--- a/cypress/integration/data_export/general/general_steps.js
+++ b/cypress/integration/data_export/general/general_steps.js
@@ -19,6 +19,30 @@ And('I cannot download transaction data', () => {
   ExportDataPage.downloadButton().should('not.exist')
 })
 
+And('return to the home page', () => {
+  TransactionsPage.visit()
+})
+
 And('I run the generate data job', () => {
-  cy.runJob('data')
+  cy.runJob('data', false)
+})
+
+Then('I can download transaction data file', () => {
+  ExportDataPage.downloadButton().should('have.attr', 'href', '/regimes/pas/data_export/download')
+})
+
+And('the transaction data file exists', () => {
+  cy.get('@regime').then((regime) => {
+    cy.task('s3Download', {
+      Bucket: Cypress.env('S3_ARCHIVE_BUCKET'),
+      remotePath: Cypress.env('S3_DATA_PATH'),
+      filePath: `${regime.slug}_transactions.csv.gz`
+    }).then((data) => {
+      if (data) {
+        cy.log('We have a file')
+      } else {
+        cy.log('We do not have a file')
+      }
+    })
+  })
 })

--- a/cypress/integration/data_export/general/general_steps.js
+++ b/cypress/integration/data_export/general/general_steps.js
@@ -15,7 +15,7 @@ And('I can download transaction data', () => {
 })
 
 Then('I am told that the transaction file has not yet been generated', () => {
-  cy.alertShouldContain('The transaction data file has not yet been generated. This file will be automatically generated overnight. Please check again tomorrow.')
+  ExportDataPage.notGeneratedAlert().should('contain.text', 'The transaction data file has not yet been generated.')
 })
 
 And('I run the generate data job', () => {

--- a/cypress/integration/data_export/general/general_steps.js
+++ b/cypress/integration/data_export/general/general_steps.js
@@ -1,5 +1,6 @@
 import { Then, And } from 'cypress-cucumber-preprocessor/steps'
-import * as os from 'os'
+
+import * as path from 'path'
 
 import ExportDataPage from '../../../pages/export_data_page'
 import TransactionsPage from '../../../pages/transactions_page'
@@ -34,7 +35,15 @@ Then('I can download transaction data file', () => {
 
 And('the transaction data file exists', () => {
   cy.get('@regime').then((regime) => {
+    // You don't need to worry if a file already exists in `cypress/downloads`. The `cy.downloadFile()` overwrites it
+    // automatically.
     const filename = `${regime.slug}_transactions.csv.gz`
-    cy.downloadFile(`${Cypress.config().baseUrl}/regimes/${regime.slug}/data_export/download`, os.tmpdir(), filename)
+    cy.downloadFile(`${Cypress.config().baseUrl}/regimes/${regime.slug}/data_export/download`, path.join('cypress', 'downloads'), filename)
+
+    const readFilename = filename
+    const writeFilename = `${regime.slug}_transactions.csv`
+    cy.task('unzip', { readFilename, writeFilename }).then((unzippedFile) => {
+      cy.wrap(unzippedFile).as('unzippedFile')
+    })
   })
 })

--- a/cypress/integration/data_export/general/general_steps.js
+++ b/cypress/integration/data_export/general/general_steps.js
@@ -14,8 +14,12 @@ And('I can download transaction data', () => {
   ExportDataPage.downloadButton().should('have.attr', 'href', '/regimes/pas/data_export/download')
 })
 
-Then('I am told that the transaction file has not yet been generated', () => {
+Then('I am told that the transaction data file has not yet been generated', () => {
   ExportDataPage.notGeneratedAlert().should('contain.text', 'The transaction data file has not yet been generated.')
+})
+
+And('I cannot download transaction data', () => {
+  ExportDataPage.downloadButton().should('not.exist')
 })
 
 And('I run the generate data job', () => {

--- a/cypress/integration/data_export/general/general_steps.js
+++ b/cypress/integration/data_export/general/general_steps.js
@@ -1,4 +1,5 @@
 import { Then, And } from 'cypress-cucumber-preprocessor/steps'
+import * as os from 'os'
 
 import ExportDataPage from '../../../pages/export_data_page'
 import TransactionsPage from '../../../pages/transactions_page'
@@ -38,11 +39,11 @@ And('the transaction data file exists', () => {
       remotePath: Cypress.env('S3_DATA_PATH'),
       filePath: `${regime.slug}_transactions.csv.gz`
     }).then((data) => {
-      if (data) {
-        cy.log('We have a file')
-      } else {
-        cy.log('We do not have a file')
-      }
+      const downloadedFilePath = `${os.tmpdir()}/${regime.slug}_transactions.csv.gz`
+
+      cy.writeFile(downloadedFilePath, data)
+      cy.wrap(downloadedFilePath).as('downloadedFilePath')
+      cy.log(`Saved file to ${downloadedFilePath}`)
     })
   })
 })

--- a/cypress/integration/data_export/general/general_steps.js
+++ b/cypress/integration/data_export/general/general_steps.js
@@ -2,8 +2,8 @@ import { Then, And } from 'cypress-cucumber-preprocessor/steps'
 import ExportDataPage from '../../../pages/export_data_page'
 import TransactionsPage from '../../../pages/transactions_page'
 
-And('I proceed to view file download details', () => {
-  TransactionsPage.transactionsMenu.getOption('Download Transaction Data').click()
+And('I proceed to view the file download details', () => {
+  TransactionsPage.transactionsMenu.getOption('Download Transaction Data', 'pas').click()
 })
 
 Then('I can view the Data Protection Notice', () => {
@@ -12,4 +12,12 @@ Then('I can view the Data Protection Notice', () => {
 
 And('I can download transaction data', () => {
   ExportDataPage.downloadButton().should('have.attr', 'href', '/regimes/pas/data_export/download')
+})
+
+Then('I am told that the transaction file has not yet been generated', () => {
+  cy.alertShouldContain('The transaction data file has not yet been generated. This file will be automatically generated overnight. Please check again tomorrow.')
+})
+
+And('I run the generate data job', () => {
+  cy.runJob('data')
 })

--- a/cypress/integration/data_export/general/general_steps.js
+++ b/cypress/integration/data_export/general/general_steps.js
@@ -34,16 +34,7 @@ Then('I can download transaction data file', () => {
 
 And('the transaction data file exists', () => {
   cy.get('@regime').then((regime) => {
-    cy.task('s3Download', {
-      Bucket: Cypress.env('S3_ARCHIVE_BUCKET'),
-      remotePath: Cypress.env('S3_DATA_PATH'),
-      filePath: `${regime.slug}_transactions.csv.gz`
-    }).then((data) => {
-      const downloadedFilePath = `${os.tmpdir()}/${regime.slug}_transactions.csv.gz`
-
-      cy.writeFile(downloadedFilePath, data)
-      cy.wrap(downloadedFilePath).as('downloadedFilePath')
-      cy.log(`Saved file to ${downloadedFilePath}`)
-    })
+    const filename = `${regime.slug}_transactions.csv.gz`
+    cy.downloadFile(`${Cypress.config().baseUrl}/regimes/${regime.slug}/data_export/download`, os.tmpdir(), filename)
   })
 })

--- a/cypress/integration/data_export/general/general_steps.js
+++ b/cypress/integration/data_export/general/general_steps.js
@@ -1,4 +1,5 @@
 import { Then, And } from 'cypress-cucumber-preprocessor/steps'
+
 import ExportDataPage from '../../../pages/export_data_page'
 import TransactionsPage from '../../../pages/transactions_page'
 
@@ -8,10 +9,6 @@ And('I proceed to view the file download details', () => {
 
 Then('I can view the Data Protection Notice', () => {
   ExportDataPage.dataProtectionNotice().should('be.visible')
-})
-
-And('I can download transaction data', () => {
-  ExportDataPage.downloadButton().should('have.attr', 'href', '/regimes/pas/data_export/download')
 })
 
 Then('I am told that the transaction data file has not yet been generated', () => {

--- a/cypress/pages/export_data_page.js
+++ b/cypress/pages/export_data_page.js
@@ -15,6 +15,10 @@ class ExportDataPage extends BaseAppPage {
   static downloadButton () {
     return cy.get('.btn.btn-primary')
   }
+
+  static notGeneratedAlert () {
+    return cy.get('.row > .alert')
+  }
 }
 
 export default ExportDataPage

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -68,6 +68,10 @@ function streamToString (stream) {
   })
 }
 
+// Adds support to download files. We use it to allow us to download things like the transaction data file export which
+// replicates following links in the UI rather than downloading them directly from AWS S3
+const { downloadFile } = require('cypress-downloadfile/lib/addPlugin')
+
 /**
  * @type {Cypress.PluginConfig}
  */
@@ -78,6 +82,8 @@ module.exports = (on, config) => {
   on('file:preprocessor', cucumber())
 
   on('task', {
+    downloadFile,
+
     s3Upload ({ Body, Bucket, remotePath, filename }) {
       // We use a template literal to combine the path and filename rather than path.join() to ensure it joins them
       // with a forward slash as required by S3 (which wouldn't happen if running under Windows).

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,6 +26,10 @@ import SignInPage from '../pages/sign_in_page'
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+// Adds support to download files. We use it to allow us to download things like the transaction data file export which
+// replicates following links in the UI rather than downloading them directly from AWS S3
+require('cypress-downloadfile/lib/downloadFileCommand')
+
 /**
  * Use when you just need to authenticate the user and avoid the UI
  *

--- a/environments/.example.env
+++ b/environments/.example.env
@@ -15,5 +15,7 @@ AWS_REGION=eu-west-1
 AWS_ACCESS_KEY_ID=access_key_id
 AWS_SECRET_ACCESS_KEY=secret_access_key
 CYPRESS_S3_BUCKET=file-uploads-dev-sroc-service-gov-uk
+CYPRESS_S3_ARCHIVE_BUCKET=file-archive-dev-sroc-service-gov-uk
 CYPRESS_S3_UPLOAD_PATH=import
 CYPRESS_S3_DOWNLOAD_PATH=export
+CYPRESS_S3_DATA_PATH=csv

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cypress": "^9.5.2",
         "cypress-cucumber-preprocessor": "^4.3.1",
         "cypress-dotenv": "^2.0.0",
+        "cypress-downloadfile": "^1.2.2",
         "dotenv": "^16.0.0",
         "path": "^0.12.7"
       },
@@ -4583,6 +4584,14 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4950,6 +4959,36 @@
       "peerDependencies": {
         "cypress": ">= 8.x",
         "dotenv": ">= 10.x"
+      }
+    },
+    "node_modules/cypress-downloadfile": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cypress-downloadfile/-/cypress-downloadfile-1.2.2.tgz",
+      "integrity": "sha512-lYR9/0hPqyXSX7Hf7ZKf6D606Mv5M0tQlVqa94h+UjXSN5nPy8GEnHuK6Mr/Av4KjG/xZOc6t4UDudO4lvZYlg==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "fs-extra": "10.1.0"
+      }
+    },
+    "node_modules/cypress-downloadfile/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cypress-downloadfile/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/cypress/node_modules/supports-color": {
@@ -7425,6 +7464,25 @@
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
@@ -9103,6 +9161,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/traverse-chain": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
@@ -9552,6 +9615,20 @@
         "is-typed-array": "^1.1.3",
         "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -13383,6 +13460,14 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -13701,6 +13786,32 @@
         "camelcase": "^6.2.0",
         "dotenv-parse-variables": "^2.0.0",
         "lodash.clonedeep": "^4.5.0"
+      }
+    },
+    "cypress-downloadfile": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cypress-downloadfile/-/cypress-downloadfile-1.2.2.tgz",
+      "integrity": "sha512-lYR9/0hPqyXSX7Hf7ZKf6D606Mv5M0tQlVqa94h+UjXSN5nPy8GEnHuK6Mr/Av4KjG/xZOc6t4UDudO4lvZYlg==",
+      "requires": {
+        "cross-fetch": "^3.1.5",
+        "fs-extra": "10.1.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
       }
     },
     "d": {
@@ -15580,6 +15691,14 @@
         "lodash": "^4.17.21"
       }
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-releases": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
@@ -16876,6 +16995,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "traverse-chain": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
@@ -17267,6 +17391,20 @@
             "which-typed-array": "^1.1.2"
           }
         }
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "cypress": "^9.5.2",
     "cypress-cucumber-preprocessor": "^4.3.1",
     "cypress-dotenv": "^2.0.0",
+    "cypress-downloadfile": "^1.2.2",
     "dotenv": "^16.0.0",
     "path": "^0.12.7"
   },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-299

In this change, we make use of the new test endpoint `/jobs/data` to expand the existing transaction file data export feature to include checking you can download the file and that its contents are as expected once the job has run.