### PR TITLE
Add github-actions to dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   versioning-strategy: lockfile-only
+- package-ecosystem: 'github-actions'
+  # Workflow files stored in the default location of `.github/workflows`
+  directory: '/'
+  schedule:
+    interval: 'daily'


### PR DESCRIPTION
The builds started failing because one of the GitHub actions used in the workflow was out of date. If dependabot was checking the actions as well as the npm packages, this would not have happened.